### PR TITLE
Base58.h change to allow importing of private keys from Vanitygen

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -365,7 +365,7 @@ public:
     void SetSecret(const CSecret& vchSecret, bool fCompressed)
     { 
         assert(vchSecret.size() == 32);
-        SetData(fTestNet ? 239 : 128, &vchSecret[0], vchSecret.size());
+        SetData(128 + (fTestNet ? CBitcoinAddress::PUBKEY_ADDRESS_TEST : CBitcoinAddress::PUBKEY_ADDRESS), &vchSecret[0], vchSecret.size());
         if (fCompressed)
             vchData.push_back(1);
     }
@@ -384,10 +384,10 @@ public:
         bool fExpectTestNet = false;
         switch(nVersion)
         {
-            case 128:
+             case (128 + CBitcoinAddress::PUBKEY_ADDRESS):
                 break;
 
-            case 239:
+            case (128 + CBitcoinAddress::PUBKEY_ADDRESS_TEST):
                 fExpectTestNet = true;
                 break;
 


### PR DESCRIPTION
Change Base58 version to allow importing of private keys from Vanitygen.

Note: Any private keys dumped from a PPCoin daemon version prior to the commit will be in an incompatible Base58 version. After installing the new version of PPCoin, simply dump the addresses again to get private keys of the correct version.
This only affects private keys dumped directly from the PPCoin daemon. Vanitygen addresses are not affected as they are the correct version, provided they are generated with the -X 55 switch.

Thanks to Sunny for further refinement of my original pull request submitted under dreamwatcher. I have changed my git account to Hartland to reflect my business name. 
