### PR TITLE
Fix memory leaks

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -308,7 +308,10 @@ bool CKey::SignCompact(uint256 hash, std::vector<unsigned char>& vchSig)
         }
 
         if (nRecId == -1)
+        {
+            ECDSA_SIG_free(sig);
             throw key_error("CKey::SignCompact() : unable to construct recoverable key");
+        }
 
         vchSig[0] = nRecId+27+(fCompressedPubKey ? 4 : 0);
         BN_bn2bin(sig->r,&vchSig[33-(nBitsR+7)/8]);
@@ -347,6 +350,7 @@ bool CKey::SetCompactSignature(uint256 hash, const std::vector<unsigned char>& v
         ECDSA_SIG_free(sig);
         return true;
     }
+    ECDSA_SIG_free(sig);
     return false;
 }
 


### PR DESCRIPTION
- fix memory leak on exception in Key::SignCompact()
  (see also bitcoin/bitcoin@6f21e73 of the bitcoin repo)
- fix memory leak in CKey::SetCompactSignature()
  (see also bitcoin/bitcoin@27e35bf of the bitcoin repo)
