### PR TITLE
Better memory management in ProcessBlock()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2038,7 +2038,12 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock)
             // Limited duplicity on stake: prevents block flood attack
             // Duplicate stake allowed only when there is orphan child block
             if (setStakeSeenOrphan.count(pblock2->GetProofOfStake()) && !mapOrphanBlocksByPrev.count(hash) && !Checkpoints::WantedByPendingSyncCheckpoint(hash))
-                return error("ProcessBlock() : duplicate proof-of-stake (%s, %d) for orphan block %s", pblock2->GetProofOfStake().first.ToString().c_str(), pblock2->GetProofOfStake().second, hash.ToString().c_str());
+            {
+                error("ProcessBlock() : duplicate proof-of-stake (%s, %d) for orphan block %s", pblock2->GetProofOfStake().first.ToString().c_str(), pblock2->GetProofOfStake().second, hash.ToString().c_str());
+                //pblock2 will not be needed, free it
+                delete pblock2;
+                return false;
+            }
             else
                 setStakeSeenOrphan.insert(pblock2->GetProofOfStake());
         }


### PR DESCRIPTION
In the shunting area on line 2031, where blocks that do not have their previous block yet are handled, there is a special case for proof-of-stake blocks. That case can fail and a return false is called. Above that there is a creation of a CBlock by new. If the return false is reached, that CBlock\* that was allocated space is not handled. All I added was a delete pblock2; to handle memory better.
