### PR TITLE
Checkpoint::CheckBlock function was renamed

### DIFF
--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -16,17 +16,17 @@ BOOST_AUTO_TEST_CASE(sanity)
 {
     uint256 p11111 = uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d");
     uint256 p134444 = uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe");
-    BOOST_CHECK(Checkpoints::CheckBlock(11111, p11111));
-    BOOST_CHECK(Checkpoints::CheckBlock(134444, p134444));
+    BOOST_CHECK(Checkpoints::CheckHardened(11111, p11111));
+    BOOST_CHECK(Checkpoints::CheckHardened(134444, p134444));
 
     
     // Wrong hashes at checkpoints should fail:
-    BOOST_CHECK(!Checkpoints::CheckBlock(11111, p134444));
-    BOOST_CHECK(!Checkpoints::CheckBlock(134444, p11111));
+    BOOST_CHECK(!Checkpoints::CheckHardened(11111, p134444));
+    BOOST_CHECK(!Checkpoints::CheckHardened(134444, p11111));
 
     // ... but any hash not at a checkpoint should succeed:
-    BOOST_CHECK(Checkpoints::CheckBlock(11111+1, p134444));
-    BOOST_CHECK(Checkpoints::CheckBlock(134444+1, p11111));
+    BOOST_CHECK(Checkpoints::CheckHardened(11111 + 1, p134444));
+    BOOST_CHECK(Checkpoints::CheckHardened(134444 + 1, p11111));
 
     BOOST_CHECK(Checkpoints::GetTotalBlocksEstimate() >= 134444);
 }    


### PR DESCRIPTION
The Checkpoint::CheckBlock but the test suite for checkpoints was not updated with the new name.
