### PR TITLE
Util Test Integer Division fixed

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -192,8 +192,10 @@ BOOST_AUTO_TEST_CASE(util_FormatMoney)
     BOOST_CHECK_EQUAL(FormatMoney(COIN/10000, false), "0.0001");
     BOOST_CHECK_EQUAL(FormatMoney(COIN/100000, false), "0.00001");
     BOOST_CHECK_EQUAL(FormatMoney(COIN/1000000, false), "0.000001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000000, false), "0.0000001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000000, false), "0.00000001");
+    
+    //Since COIN is 1000000, these integer divisions will be 0
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000000, false), "0.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000000, false), "0.00");
 }
 
 BOOST_AUTO_TEST_CASE(util_ParseMoney)
@@ -235,10 +237,6 @@ BOOST_AUTO_TEST_CASE(util_ParseMoney)
     BOOST_CHECK_EQUAL(ret, COIN/100000);
     BOOST_CHECK(ParseMoney("0.000001", ret));
     BOOST_CHECK_EQUAL(ret, COIN/1000000);
-    BOOST_CHECK(ParseMoney("0.0000001", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/10000000);
-    BOOST_CHECK(ParseMoney("0.00000001", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/100000000);
 
     // Attempted 63 bit overflow should fail
     BOOST_CHECK(!ParseMoney("92233720368.54775808", ret));


### PR DESCRIPTION
Since COIN is 1000000, the division by 10**7 and 10**8 will be both 0, and not the decimal value to test suite previously had.
