### PR TITLE
Fixed net.h to solve mingw ws2tcpip.h incompatability errors

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -6,6 +6,11 @@
 #ifndef BITCOIN_NET_H
 #define BITCOIN_NET_H
 
+#include "mruset.h"
+#include "netbase.h"
+#include "protocol.h"
+#include "addrman.h"
+
 #include <deque>
 #include <boost/array.hpp>
 #include <boost/foreach.hpp>
@@ -14,11 +19,6 @@
 #ifndef WIN32
 #include <arpa/inet.h>
 #endif
-
-#include "mruset.h"
-#include "netbase.h"
-#include "protocol.h"
-#include "addrman.h"
 
 class CAddrDB;
 class CRequestTracker;


### PR DESCRIPTION
When compiling on mingw, when including compat.h as a sub-part of including checkpoints.h, ws2tcpip.h header is included. That header would complain that it is incompatible with winsock.h, meaning it was included somewhere before. It turned out that openssl/rand.h has a preprocessor case that includes windows.h, which inside winsock.h, causing the later error. Simply be moving the mruset/netbase/protocol/addrman includes above openssl/rand.h fixes the issue of comparability.
