### PR TITLE
Wallet refuses to create mints with zero reward. 

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1354,7 +1354,13 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         CTxDB txdb("r");
         if (!txNew.GetCoinAge(txdb, nCoinAge))
             return error("CreateCoinStake : failed to calculate coin age");
-        nCredit += GetProofOfStakeReward(nCoinAge);
+
+        int64 nReward = GetProofOfStakeReward(nCoinAge);
+        // Refuse to create mint that has zero or negative reward
+        if(nReward <= 0) {
+          return false;
+        }
+        nCredit += nReward;
     }
 
     int64 nMinFee = 0;


### PR DESCRIPTION
This pull request is reaction to issue #56, where I argued that thanks to rounding in the reward function, wallets sometimes create mints of zero value, which robs them of the coinage, but they gain nothing in return. This change causes that if the wallet generates mint with zero reward, it refuses to create it. There is no change in the protocol and the change is completely on the side of the wallet. 

It can still happen that the mint is zero or negative because of the fees for size. (Example - [block 69530](http://www.peercointalk.org/index.php?topic=2869.0).) But this is not to be prevented, since the mint transaction does work of joining the stakes without transaction fee, so unlike in the case of zero reward, there is benefit to the wallet in such case. 
