### PR TITLE
Explicitly use array from boost namespace

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -51,7 +51,7 @@ CAddress addrLocalHost(CService("0.0.0.0", 0), nLocalServices);
 CAddress addrSeenByPeer(CService("0.0.0.0", 0), nLocalServices);
 static CNode* pnodeLocalHost = NULL;
 uint64 nLocalHostNonce = 0;
-array<int, THREAD_MAX> vnThreadsRunning;
+boost::array<int, THREAD_MAX> vnThreadsRunning;
 static SOCKET hListenSocket = INVALID_SOCKET;
 CAddrMan addrman;
 


### PR DESCRIPTION
Compiling with GCC-6 breaks with:

`net.cpp:54:1: error: reference to 'array' is ambiguous`
 `array<int, THREAD_MAX> vnThreadsRunning;`
`^~~~~`

`boost` and `std` namespaces both define `array`.
Use `boost::array` to be explicit to avoid ambiguity.
