### PR TITLE
[ppcoin v0.6] Prevent premature activation of BIP34 softfork

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -53,6 +53,13 @@ bool IsProtocolV05(unsigned int nTimeTx)
     return (nTimeTx >= (fTestNet? nProtocolV05TestSwitchTime : nProtocolV05SwitchTime));
 }
 
+// Whether a given block is subject to new v0.6 protocol
+bool IsProtocolV06(unsigned int nTimeBlock)
+{
+    // TODO decide on upgrade timing
+    return false;
+}
+
 // Get the last stake modifier and its generation time from a given block
 static bool GetLastStakeModifier(const CBlockIndex* pindex, uint64& nStakeModifier, int64& nModifierTime)
 {

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -24,6 +24,8 @@ bool IsProtocolV03(unsigned int nTimeCoinStake);
 bool IsProtocolV04(unsigned int nTimeBlock);
 // Whether a given transaction is subject to new v0.5 protocol
 bool IsProtocolV05(unsigned int nTimeTx);
+// Whether a given block is subject to new v0.6 protocol
+bool IsProtocolV06(unsigned int nTimeBlock);
 
 // Compute the hash modifier for proof-of-stake
 bool ComputeNextStakeModifier(const CBlockIndex* pindexCurrent, uint64& nStakeModifier, bool& fGeneratedStakeModifier);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2426,7 +2426,7 @@ bool CBlock::AcceptBlock(CValidationState &state, CDiskBlockPos *dbp)
             return state.Invalid(error("AcceptBlock() : rejected by synchronized checkpoint"));
 
         // Reject block.nVersion=1 blocks when 95% (75% on testnet) of the network has upgraded:
-        if (nVersion < 2)
+        if (nVersion < 2 && IsProtocolV06(nTime))
         {
             if ((!fTestNet && CBlockIndex::IsSuperMajority(2, pindexPrev, 950, 1000)) ||
                 (fTestNet && CBlockIndex::IsSuperMajority(2, pindexPrev, 75, 100)))
@@ -2435,7 +2435,7 @@ bool CBlock::AcceptBlock(CValidationState &state, CDiskBlockPos *dbp)
             }
         }
         // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
-        if (nVersion >= 2)
+        if (nVersion >= 2 && IsProtocolV06(nTime))
         {
             // if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
             if ((!fTestNet && CBlockIndex::IsSuperMajority(2, pindexPrev, 750, 1000)) ||


### PR DESCRIPTION
On testnet, the BIP34 softfork get's accidently activated prematurely. Probably due to experimentation with the version number on testnet.

A protocol v0.6 switchtime should still be decided on.
Note that BIP34 is just a soft fork, legacy clients will still accept blocks created after activation.