### PR TITLE
Specify which array in net.cpp

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -51,7 +51,7 @@ CAddress addrLocalHost(CService("0.0.0.0", 0), nLocalServices);
 CAddress addrSeenByPeer(CService("0.0.0.0", 0), nLocalServices);
 static CNode* pnodeLocalHost = NULL;
 uint64 nLocalHostNonce = 0;
-array<int, THREAD_MAX> vnThreadsRunning;
+boost::array<int, THREAD_MAX> vnThreadsRunning;
 static SOCKET hListenSocket = INVALID_SOCKET;
 CAddrMan addrman;
 


### PR DESCRIPTION
Compilation failed for me in net.cpp because array was ambiguous, either boost or std.