### PR TITLE
CWalletTx::GetTxTime() should return the peercoin txtime

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -597,8 +597,11 @@ bool CWallet::IsChange(const CTxOut& txout) const
 
 int64 CWalletTx::GetTxTime() const
 {
-    int64 n = nTimeSmart;
-    return n ? n : nTimeReceived;
+    //int64 n = nTimeSmart;
+    //return n ? n : nTimeReceived;
+
+    //ppcoin: we still have the timestamp, so use it to avoid confusion
+    return nTime;
 }
 
 int CWalletTx::GetRequestCount() const


### PR DESCRIPTION
Avoid confusion, we still did not remove the timestamp, so let's stick to it.

Fixes: https://github.com/peercoin/peercoin/issues/156