### PR TITLE
Add bound checks to CScriptCheck to avoid std::bad_alloc errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1430,6 +1430,8 @@ bool CTransaction::HaveInputs(CCoinsViewCache &inputs) const
 
 bool CScriptCheck::operator()() const {
     const CScript &scriptSig = ptxTo->vin[nIn].scriptSig;
+    if (scriptPubKey.size() == 0)
+        return false;
     if (!VerifyScript(scriptSig, scriptPubKey, *ptxTo, nIn, nFlags, nHashType))
         return error("CScriptCheck() : %s VerifySignature failed", ptxTo->GetHash().ToString().c_str());
     return true;

--- a/src/main.h
+++ b/src/main.h
@@ -1207,8 +1207,12 @@ private:
 public:
     CScriptCheck() {}
     CScriptCheck(const CCoins& txFromIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn, int nHashTypeIn) :
-        scriptPubKey(txFromIn.vout[txToIn.vin[nInIn].prevout.n].scriptPubKey),
-        ptxTo(&txToIn), nIn(nInIn), nFlags(nFlagsIn), nHashType(nHashTypeIn) { }
+        ptxTo(&txToIn), nIn(nInIn), nFlags(nFlagsIn), nHashType(nHashTypeIn)
+    {
+        if (nInIn < txToIn.vin.size() &&
+            txToIn.vin[nInIn].prevout.n < txFromIn.vout.size())
+            scriptPubKey = txFromIn.vout[txToIn.vin[nInIn].prevout.n].scriptPubKey;
+    }
 
     bool operator()() const;
 


### PR DESCRIPTION
Add bound checks to CScriptCheck to avoid std::bad_alloc errors on transactions referencing invalid inputs