### PR TITLE
Fix VerifySignature mistakes made with v0.6 port

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -480,7 +480,7 @@ bool CheckProofOfStake(CValidationState &state, const CTransaction& tx, unsigned
 
     // Verify signature
     CCoins coins(txPrev, 0);
-    if (!VerifySignature(coins, tx, 0, true, 0))
+    if (!VerifySignature(coins, tx, 0, SCRIPT_VERIFY_P2SH, 0))
         return state.DoS(100, error("CheckProofOfStake() : VerifySignature failed on coinstake %s", tx.GetHash().ToString().c_str()));
 
     if (!CheckStakeKernelHash(nBits, header, postx.nTxOffset + sizeof(CBlockHeader), txPrev, txin.prevout, tx.nTime, hashProofOfStake, fDebug))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1463,6 +1463,10 @@ bool CScriptCheck::operator()() const {
 
 bool VerifySignature(const CCoins& txFrom, const CTransaction& txTo, unsigned int nIn, unsigned int flags, int nHashType)
 {
+    assert(nIn < txTo.vin.size());
+    if (txTo.vin[nIn].prevout.n >= txFrom.vout.size())
+        return false;
+
     return CScriptCheck(txFrom, txTo, nIn, flags, nHashType)();
 }
 


### PR DESCRIPTION
The bool fValidatePayToScriptHash got replaced by script verification flags but the call still passed a boolean as the new flag parameter.

Bound checks missing from CScriptCheck triggers std::bad_alloc errors on coinstake validation on some invalid testnet blocks.