### PR TITLE
Revert "Cancel the best block when a duplicate stake is received"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2542,39 +2542,10 @@ bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBl
         return state.Invalid(error("ProcessBlock() : already have block (orphan) %s", hash.ToString().c_str()));
 
     // ppcoin: check proof-of-stake
-    if (pblock->IsProofOfStake())
-    {
-        std::pair<COutPoint, unsigned int> proofOfStake = pblock->GetProofOfStake();
-
-        if (pindexBest->IsProofOfStake() && proofOfStake.first == pindexBest->prevoutStake)
-        {
-            // The best block's stake is reused, we cancel the best block
-
-            // Only reject the best block if the duplicate is correctly signed
-            if (!pblock->CheckBlockSignature())
-                return state.DoS(100, error("ProcessBlock() : Invalid signature in duplicate block"));
-
-            printf("ProcessBlock() : block uses the same stake as the best block. Canceling the best block\n");
-
-            // Relay the duplicate block so that other nodes are aware of the duplication
-            RelayBlock(*pblock, hash);
-
-            // Cancel the best block
-            InvalidBlockFound(pindexBest);
-            CValidationState stateDummy;
-            if (!SetBestChain(stateDummy, pindexBest->pprev))
-                return error("ProcessBlock(): SetBestChain on previous best block failed");
-
-            return false;
-        }
-        else
-        {
-            // Limited duplicity on stake: prevents block flood attack
-            // Duplicate stake allowed only when there is orphan child block
-            if (pblock->IsProofOfStake() && setStakeSeen.count(proofOfStake) && !mapOrphanBlocksByPrev.count(hash) && !WantedByPendingSyncCheckpoint(hash))
-                return error("ProcessBlock() : duplicate proof-of-stake (%s, %d) for block %s", proofOfStake.first.ToString().c_str(), proofOfStake.second, hash.ToString().c_str());
-        }
-    }
+    // Limited duplicity on stake: prevents block flood attack
+    // Duplicate stake allowed only when there is orphan child block
+    if (pblock->IsProofOfStake() && setStakeSeen.count(pblock->GetProofOfStake()) && !mapOrphanBlocksByPrev.count(hash) && !WantedByPendingSyncCheckpoint(hash))
+        return error("ProcessBlock() : duplicate proof-of-stake (%s, %d) for block %s", pblock->GetProofOfStake().first.ToString().c_str(), pblock->GetProofOfStake().second, hash.ToString().c_str());
 
     // Preliminary checks
     if (!pblock->CheckBlock(state))
@@ -3566,16 +3537,12 @@ void static ProcessGetData(CNode* pfrom)
             boost::this_thread::interruption_point();
             it++;
 
-            // ppcoin: relay memory may contain blocks too
-            bool found = false;
-
             if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK)
             {
                 // Send block from disk
                 map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(inv.hash);
                 if (mi != mapBlockIndex.end())
                 {
-                    found = true;
                     CBlock block;
                     block.ReadFromDisk((*mi).second);
                     if (inv.type == MSG_BLOCK)
@@ -3618,8 +3585,7 @@ void static ProcessGetData(CNode* pfrom)
                     }
                 }
             }
-
-            if (!found && inv.IsKnownType())
+            else if (inv.IsKnownType())
             {
                 // Send stream from relay memory
                 bool pushed = false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1877,8 +1877,9 @@ void RelayTransaction(const CTransaction& tx, const uint256& hash)
     RelayTransaction(tx, hash, ss);
 }
 
-static void AddRelay(const CInv& inv, const CDataStream& ss)
+void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataStream& ss)
 {
+    CInv inv(MSG_TX, hash);
     {
         LOCK(cs_mapRelay);
         // Expire old relay messages
@@ -1892,12 +1893,6 @@ static void AddRelay(const CInv& inv, const CDataStream& ss)
         mapRelay.insert(std::make_pair(inv, ss));
         vRelayExpiration.push_back(std::make_pair(GetTime() + 15 * 60, inv));
     }
-}
-
-void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataStream& ss)
-{
-    CInv inv(MSG_TX, hash);
-    AddRelay(inv, ss);
     LOCK(cs_vNodes);
     BOOST_FOREACH(CNode* pnode, vNodes)
     {
@@ -1911,21 +1906,4 @@ void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataSt
         } else
             pnode->PushInventory(inv);
     }
-}
-
-void RelayBlock(const CBlock& block, const uint256& hash)
-{
-    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-    ss.reserve(10000);
-    ss << block;
-    RelayBlock(block, hash, ss);
-}
-
-void RelayBlock(const CBlock& tx, const uint256& hash, const CDataStream& ss)
-{
-    CInv inv(MSG_BLOCK, hash);
-    AddRelay(inv, ss);
-    LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
-        pnode->PushInventory(inv);
 }

--- a/src/net.h
+++ b/src/net.h
@@ -643,8 +643,4 @@ class CTransaction;
 void RelayTransaction(const CTransaction& tx, const uint256& hash);
 void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataStream& ss);
 
-class CBlock;
-void RelayBlock(const CBlock& tx, const uint256& hash);
-void RelayBlock(const CBlock& tx, const uint256& hash, const CDataStream& ss);
-
 #endif


### PR DESCRIPTION
This reverts commit d2d4ff4a9b61939a17f2d3623518809d2045053c.

This counter measure to reusing stake causes issues with blockchain validation and can cause avoidable forks.

Compiling and unit tests passing.
This is a naive revert of the commit introducing the change, it should be reviewed and tested extensively before merging.