### PR TITLE
Duplicate best block fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,7 @@ int64 CTransaction::nMinRelayTxFee = MIN_RELAY_TX_FEE;
 CMedianFilter<int> cPeerBlockCounts(8, 0); // Amount of blocks that other nodes claim to have
 
 map<uint256, CBlock*> mapOrphanBlocks;
+map<uint256, CBlock*> mapDuplicateStakeBlocks;
 multimap<uint256, CBlock*> mapOrphanBlocksByPrev;
 set<pair<COutPoint, unsigned int> > setStakeSeenOrphan;
 map<uint256, uint256> mapProofOfStake;
@@ -2533,6 +2534,23 @@ bool CBlockIndex::IsSuperMajority(int minVersion, const CBlockIndex* pstart, uns
     return (nFound >= nRequired);
 }
 
+void CleanUpOldDuplicateStakeBlocks()
+{
+    uint64 maxAge = 24 * 60 * 60;
+    uint64 minTime = GetAdjustedTime() - maxAge;
+
+    BOOST_FOREACH(PAIRTYPE(const uint256, CBlock*)& item, mapDuplicateStakeBlocks)
+    {
+        const uint256& hash = item.first;
+        CBlock* block = item.second;
+        if (block->GetBlockTime() < minTime)
+        {
+            mapDuplicateStakeBlocks.erase(hash);
+            delete block;
+        }
+    }
+}
+
 bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBlockPos *dbp)
 {
 #ifdef TESTING
@@ -2554,31 +2572,14 @@ bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBl
         return state.Invalid(error("ProcessBlock() : already have block (orphan) %s", hash.ToString().c_str()));
 
     // ppcoin: check proof-of-stake
+    bool fDuplicateStakeOfBestBlock = false;
     if (pblock->IsProofOfStake())
     {
         std::pair<COutPoint, unsigned int> proofOfStake = pblock->GetProofOfStake();
 
         if (pindexBest->IsProofOfStake() && proofOfStake.first == pindexBest->prevoutStake)
-        {
-            // The best block's stake is reused, we cancel the best block
-
-            // Only reject the best block if the duplicate is correctly signed
-            if (!pblock->CheckBlockSignature())
-                return state.DoS(100, error("ProcessBlock() : Invalid signature in duplicate block"));
-
-            printf("ProcessBlock() : block uses the same stake as the best block. Canceling the best block\n");
-
-            // Relay the duplicate block so that other nodes are aware of the duplication
-            RelayBlock(*pblock, hash);
-
-            // Cancel the best block
-            InvalidBlockFound(pindexBest);
-            CValidationState stateDummy;
-            if (!SetBestChain(stateDummy, pindexBest->pprev))
-                return error("ProcessBlock(): SetBestChain on previous best block failed");
-
-            return false;
-        }
+            // If the best block's stake is reused, we cancel the best block after the block checks
+            fDuplicateStakeOfBestBlock = true;
         else
         {
             // Limited duplicity on stake: prevents block flood attack
@@ -2624,6 +2625,40 @@ bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBl
     // ppcoin: ask for pending sync-checkpoint if any
     if (!IsInitialBlockDownload())
         AskForPendingSyncCheckpoint(pfrom);
+
+    if (fDuplicateStakeOfBestBlock)
+    {
+        printf("ProcessBlock() : block uses the same stake as the best block. Canceling the best block\n");
+
+        // Save the block to be able to accept it if a new chain is built from it despite the rejection
+        mapDuplicateStakeBlocks[pblock->GetHash()] = new CBlock(*pblock);
+
+        // Relay the duplicate block so that other nodes are aware of the duplication
+        RelayBlock(*pblock, hash);
+
+        // Cancel the best block
+        setBlockIndexValid.erase(pindexBest); // Remove from the list of immediate candidates for the best chain
+        InvalidChainFound(pindexBest);
+        CValidationState stateDummy;
+        if (!SetBestChain(stateDummy, pindexBest->pprev))
+            return error("ProcessBlock(): SetBestChain on previous best block failed");
+
+        return false;
+    }
+
+    if (!mapBlockIndex.count(pblock->hashPrevBlock) && mapDuplicateStakeBlocks.count(pblock->hashPrevBlock))
+    {
+        printf("ProcessBlock() : parent block was previously rejected because of stake duplication. Reaccepting parent\n");
+        CBlock* pprevBlock = mapDuplicateStakeBlocks[pblock->hashPrevBlock];
+        // Block was already checked when it was first received, so we can just accept it here
+        if (!pprevBlock->AcceptBlock(state, dbp))
+            return error("ProcessBlock() : AcceptBlock of previously duplicate block FAILED");
+        mapDuplicateStakeBlocks.erase(pblock->hashPrevBlock);
+        delete pprevBlock;
+    }
+
+    if (mapDuplicateStakeBlocks.size())
+        CleanUpOldDuplicateStakeBlocks();
 
     // If we don't already have its previous block, shunt it off to holding area until we get it
     if (pblock->hashPrevBlock != 0 && !mapBlockIndex.count(pblock->hashPrevBlock))

--- a/src/main.h
+++ b/src/main.h
@@ -121,6 +121,7 @@ extern bool fTxIndex;
 extern unsigned int nCoinCacheSize;
 #ifdef TESTING
 extern uint256 hashSingleStakeBlock;
+extern int nBlocksToIgnore;
 #endif
 
 // Settings
@@ -204,7 +205,7 @@ std::string GetWarnings(std::string strFor);
 uint256 WantedByOrphan(const CBlock* pblockOrphan);
 const CBlockIndex* GetLastBlockIndex(const CBlockIndex* pindex, bool fProofOfStake);
 #ifdef TESTING
-void BitcoinMiner(CWallet *pwallet, bool fProofOfStake, bool fGenerateSingleBlock = false, CBlockIndex* parent = NULL);
+void BitcoinMiner(CWallet *pwallet, bool fProofOfStake, bool fGenerateSingleBlock = false);
 #else
 void BitcoinMiner(CWallet *pwallet, bool fProofOfStake);
 #endif

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -36,7 +36,7 @@ LIBS= \
 
 DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
 DEBUGFLAGS=-g
-xCXXFLAGS=-O2 -w -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS) $(CXXFLAGS)
+xCXXFLAGS=-O2 -std=c++11 -w -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS) $(CXXFLAGS)
 # enable: ASLR, DEP and large address aware
 xLDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -Wl,--large-address-aware $(LDFLAGS)
 

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -103,7 +103,7 @@ LIBS= \
 
 DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
 DEBUGFLAGS=-g
-CFLAGS=-mthreads -O2 -w -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
+CFLAGS=-std=c++11 -mthreads -O2 -w -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 # enable: ASLR, DEP and large address aware
 LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -Wl,--large-address-aware
 

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -74,7 +74,7 @@ DEBUGFLAGS = -g
 endif
 
 # ppc doesn't work because we don't support big-endian
-CFLAGS += -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \
+CFLAGS += -std=c++11 -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \
     $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 
 OBJS= \

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -104,7 +104,7 @@ DEBUGFLAGS=-g
 
 # CXXFLAGS can be specified on the make command line, so we use xCXXFLAGS that only
 # adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
-xCXXFLAGS=-O2 -pthread -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \
+xCXXFLAGS=-O2 -std=c++11 -pthread -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 # LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1029,6 +1029,7 @@ void ThreadSocketHandler()
                     SocketSendData(pnode);
             }
 
+#ifndef TESTING
             //
             // Inactivity checking
             //
@@ -1052,6 +1053,7 @@ void ThreadSocketHandler()
                     pnode->fDisconnect = true;
                 }
             }
+#endif
         }
         {
             LOCK(cs_vNodes);

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -239,7 +239,7 @@ Value listunspent(const Array& params, bool fHelp)
             CTxDestination address;
             if (ExtractDestination(pk, address))
             {
-                const CScriptID& hash = boost::get<const CScriptID&>(address);
+                const CScriptID& hash = boost::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))
                     entry.push_back(Pair("redeemScript", HexStr(redeemScript.begin(), redeemScript.end())));

--- a/src/test/Gemfile.lock
+++ b/src/test/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       archive-tar-minitar
       excon (>= 0.38.0)
       json
-    excon (0.39.5)
+    excon (0.57.1)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     httparty (0.13.1)
@@ -37,3 +37,6 @@ DEPENDENCIES
   docker-api
   httparty
   rspec-expectations
+
+BUNDLED WITH
+   1.12.5

--- a/src/test/containers/attach
+++ b/src/test/containers/attach
@@ -25,4 +25,4 @@ end
 container = containers[n]
 id = container.id
 
-exec "docker logs #{id} | less"
+exec "docker attach #{id}"

--- a/src/test/containers/base/Dockerfile
+++ b/src/test/containers/base/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8842CE5E
 RUN echo deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu trusty main >/etc/apt/sources.list.d/bitcoin.list
 RUN apt-get update
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-RUN apt-get install -y libboost-filesystem1.54.0 libboost-program-options1.54.0 libboost-thread1.54.0
-RUN apt-get install -y libdb4.8++
+RUN apt-get install -y libboost-filesystem1.58.0 libboost-program-options1.58.0 libboost-thread1.58.0 libdb4.8++
+RUN apt-get install -y libssl1.0.0

--- a/src/test/containers/base_devel/Dockerfile
+++ b/src/test/containers/base_devel/Dockerfile
@@ -1,8 +1,6 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8842CE5E
-RUN echo deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu trusty main >/etc/apt/sources.list.d/bitcoin.list
+RUN echo deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main >/etc/apt/sources.list.d/bitcoin.list
 RUN apt-get update
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-RUN apt-get install -y git build-essential g++
-RUN apt-get install -y libboost-all-dev libdb4.8++-dev libqrencode-dev
-RUN apt-get install -y libssl-dev
+RUN apt-get install -y git build-essential g++ libboost-all-dev libdb4.8++-dev libqrencode-dev libssl-dev

--- a/src/test/containers/build_net
+++ b/src/test/containers/build_net
@@ -2,11 +2,13 @@
 
 require File.expand_path('../boot', __FILE__)
 
+shift = (Time.at(1345090000) - Time.now).to_i + 30 * 24 * 3600
+
 puts "Starting seed"
 seed = CoinContainer.new(
   image: 'peercoin/seed',
   args: {
-    "timetravel" => -60*24*3600,
+    "timetravel" => shift,
   }
 )
 seed.wait_for_boot
@@ -19,7 +21,7 @@ nodes = node_names.map do |name|
     links: [seed.name],
     delete_at_exit: true,
     args: {
-      "timetravel" => -60*24*3600,
+      "timetravel" => shift,
     }
   )
 end
@@ -37,9 +39,13 @@ nodes.each_with_index do |node, i|
 
     amount_per_output = (amount / outputs).to_i
     puts "Sending #{amount_string} to node #{node_names[i]} in #{outputs} transactions of #{amount_per_output}"
-    outputs.times do
+    outputs.times do |i|
       seed.rpc("sendtoaddress", address, amount_per_output)
+      print "\r#{i + 1}"
+      STDOUT.flush
     end
+    puts
+    puts "Generating block to confirm"
     seed.generate_stake
 end
 
@@ -54,9 +60,13 @@ loop do
   end
 end
 
-
 nModifierInterval=60*20
 count = 64
+
+puts "Moving near protocol v5 switch time"
+shift = 1447700000 -  Time.parse(seed.info["time"]).to_i - count * nModifierInterval
+all.each { |n| n.rpc("timetravel", shift) }
+
 puts "Building next #{count} blocks at nModifierInterval intervals (#{nModifierInterval} seconds)"
 count.times do |i|
   all.each { |n| n.rpc("timetravel", nModifierInterval) }
@@ -66,11 +76,17 @@ count.times do |i|
 end
 puts
 
-puts "Building 10 more blocks at 1 minute intervals"
-10.times do |i|
-  all.each { |n| n.rpc("timetravel", 60) }
+puts "Moving to current time"
+START_TIME = Time.utc(2017, 1, 1, 12, 0, 0)
+last_blocks_interval = 40000
+shift = (START_TIME - Time.parse(seed.info["time"])).to_i
+last_blocks_count = shift / last_blocks_interval
+
+puts "Building #{last_blocks_count} more blocks at #{last_blocks_interval} seconds intervals to reach #{START_TIME}"
+last_blocks_count.times do |i|
+  all.each { |n| n.rpc("timetravel", last_blocks_interval) }
   seed.generate_stake
-  print "\r%2d/%2d" % [i+1, 10]
+  print "\r%2d/%2d" % [i+1, last_blocks_count]
   STDOUT.flush
 end
 puts
@@ -79,7 +95,7 @@ seed_height = seed.block_count
 
 puts "Waiting for all nodes to sync at seed height (#{seed_height})"
 loop do
-  heights = nodes.map(&:block_count)
+  heights = all.map(&:block_count)
   p heights
   break if heights.all? { |h| h == seed_height }
   sleep 1

--- a/src/test/containers/coin_container.rb
+++ b/src/test/containers/coin_container.rb
@@ -33,9 +33,10 @@ class CoinContainer
     end
     name = options[:name]
 
+    connect_cmd = (options[:link_with_connect] ? "-connect" : "-addnode")
     connects = links.map do |linked_name, alias_name|
       upname = alias_name.upcase
-      "-addnode=$#{upname}_PORT_9903_TCP_ADDR:$#{upname}_PORT_9903_TCP_PORT"
+      "#{connect_cmd}=$#{upname}_PORT_9903_TCP_ADDR:$#{upname}_PORT_9903_TCP_PORT"
     end
 
     default_args = {

--- a/src/test/containers/coin_container.rb
+++ b/src/test/containers/coin_container.rb
@@ -72,14 +72,14 @@ class CoinContainer
       bash_cmd += "echo Environment:; env; "
     end
 
-    bash_cmd += "./ppcoind " + cmd_args.join(" ")
+    bash_cmd += "./peercoind " + cmd_args.join(" ")
 
     if options[:remove_addr_after_shutdown]
-      bash_cmd += "; rm /.ppcoin/testnet/addr.dat"
+      bash_cmd += "; rm -f /root/.peercoin/testnet/peers.dat"
     end
 
     if options[:remove_wallet_after_shutdown]
-      bash_cmd += "; rm /.ppcoin/testnet/wallet.dat"
+      bash_cmd += "; rm /root/.peercoin/testnet/wallet.dat"
     end
 
     command = [
@@ -115,8 +115,8 @@ class CoinContainer
     node_container.start(
       'Binds' => ["#{File.expand_path('../../..', __FILE__)}:/code"],
       'PortBindings' => {
-        "9904/tcp" => ['127.0.0.1'],
-        "9903/tcp" => ['127.0.0.1'],
+        "9904/tcp" => [{}],
+        "9903/tcp" => [{}],
       },
       'Links' => links.map { |link_name, alias_name| "#{link_name}:#{alias_name}" },
     )

--- a/src/test/containers/node
+++ b/src/test/containers/node
@@ -3,5 +3,5 @@
 cd $(dirname $0)/../..
 
 set -x
-docker run -v $PWD/..:/code -p '0.0.0.0::9903' -p '0.0.0.0::9904' -w /code/src --tty peercoin/base ./ppcoind "$@"
+docker run -v $PWD/..:/code -p '0.0.0.0::9903' -p '0.0.0.0::9904' -w /code/src --tty peercoin/base ./peercoind "$@"
 

--- a/src/test/features/revert_duplicate.feature
+++ b/src/test/features/revert_duplicate.feature
@@ -14,14 +14,41 @@ Feature: The top block is removed if a duplicate stake is received
 
   Scenario: A node builds a block on top of a block that was removed because of duplication
     Given a network with nodes "A", "B" and "C" able to mint
+    And a node "D" connected only to node "A"
+
     When node "A" finds a block "X"
     Then all nodes should be at block "X"
+
+    When node "B" finds a block "Y" not received by node "C"
+    Then nodes "A", "B" and "D" should be at block "Y"
+    And node "C" should be at block "X"
+
+    When node "B" sends a duplicate "Y2" of block "Y"
+    Then nodes "A", "B" and "D" should be at block "X"
+    And node "C" should be at block "Y2"
+
+    When node "C" finds a block "Z"
+    Then all nodes should be at block "Z"
+    And node "D" should have 1 connection
+
+
+  Scenario: A node builds a block on top of a duplicated block
+    Given a network with nodes "A", "B" and "C" able to mint
+    And a node "D" connected only to node "A"
+
+    When node "A" finds a block "X"
+    Then all nodes should be at block "X"
+
     When node "B" finds a block "Y"
     Then all nodes should be at block "Y"
-    When node "B" sends a duplicate "Y2" of block "Y"
-    Then all nodes should be at block "X"
-    When node "C" finds a block "Z" on top of block "Y2"
+
+    When node "B" sends a duplicate "Y2" of block "Y" not received by node "C"
+    Then nodes "A", "B" and "D" should be at block "X"
+    And node "C" should be at block "Y"
+
+    When node "C" finds a block "Z"
     Then all nodes should be at block "Z"
+    And node "D" should have 1 connection
 
 
   Scenario: Transactions unconfirmed by duplicate removal gets confirmed again in the next block

--- a/src/test/features/step_definitions/common.rb
+++ b/src/test/features/step_definitions/common.rb
@@ -42,6 +42,25 @@ Given(/^a network with nodes? (.+) able to mint$/) do |node_names|
   end
 end
 
+Given(/^a node "(.*?)" connected only to node "(.*?)"$/) do |arg1, arg2|
+  other_node = @nodes[arg2]
+  name = arg1
+  shift = (Time.parse(other_node.info["time"]) - Time.now).to_i
+  options = {
+    image: "peercoinnet/a",
+    links: [other_node.name],
+    link_with_connect: true,
+    args: {
+      debug: true,
+      timetravel: shift,
+    },
+    remove_wallet_before_startup: true,
+  }
+  node = CoinContainer.new(options)
+  @nodes[name] = node
+  node.wait_for_boot
+end
+
 After do
   if @nodes
     require 'thread'
@@ -62,6 +81,12 @@ When(/^node "(.*?)" finds a block "([^"]*?)"$/) do |node, block|
   @blocks[block] = @nodes[node].generate_stake
 end
 
+When(/^node "(.*?)" finds a block "([^"]*?)" not received by node "([^"]*?)"$/) do |node, block, other|
+  @nodes.each { |name, n| n.rpc("timetravel", 5) }
+  @nodes[other].rpc("ignorenextblock")
+  @blocks[block] = @nodes[node].generate_stake
+end
+
 When(/^node "(.*?)" finds a block$/) do |node|
   @nodes[node].generate_stake
 end
@@ -73,11 +98,27 @@ Then(/^all nodes should be at block "(.*?)"$/) do |block|
       main.all? { |hash| hash == @blocks[block] }
     end
   rescue
-    raise "Not at block #{block}: #{@nodes.values.map(&:top_hash).map { |hash| @blocks.key(hash) }.inspect}"
+    require 'pp'
+    pp @blocks
+    raise "Not at block #{block}: #{@nodes.values.map(&:top_hash).map { |hash| @blocks.key(hash) || hash }.inspect}"
   end
 end
 
-Given(/^all nodes reach the same height$/) do
+Then(/^nodes? (.+) (?:should be at|should reach|reach|reaches|is at|are at) block "(.*?)"$/) do |node_names, block|
+  nodes = node_names.scan(/"(.*?)"/).map { |name, | @nodes[name] }
+  begin
+    wait_for do
+      main = nodes.map(&:top_hash)
+      main.all? { |hash| hash == @blocks[block] }
+    end
+  rescue
+    require 'pp'
+    pp @blocks
+    raise "Not at block #{block}: #{nodes.map(&:top_hash).map { |hash| @blocks.key(hash) || hash }.inspect}"
+  end
+end
+
+Given(/^all nodes (?:should )?reach the same height$/) do
   wait_for do
     expect(@nodes.values.map(&:block_count).uniq.size).to eq(1)
   end
@@ -118,4 +159,8 @@ Then(/^all nodes should (?:have|reach) (\d+) transactions? in memory pool$/) do 
   wait_for do
     expect(@nodes.values.map { |node| node.rpc("getmininginfo")["pooledtx"] }).to eq(@nodes.map { arg1.to_i })
   end
+end
+
+Then(/^node "(.*?)" should have (\d+) connection$/) do |arg1, arg2|
+  expect(@nodes[arg1].info["connections"]).to eq(arg2.to_i)
 end

--- a/src/test/features/step_definitions/common.rb
+++ b/src/test/features/step_definitions/common.rb
@@ -5,6 +5,8 @@ Before do
   @tx = {}
 end
 
+START_TIME = Time.utc(2017, 1, 1, 12, 0, 0)
+
 Given(/^a network with nodes? (.+) able to mint$/) do |node_names|
   node_names = node_names.scan(/"(.*?)"/).map(&:first)
   available_nodes = %w( a b c d e )
@@ -12,12 +14,13 @@ Given(/^a network with nodes? (.+) able to mint$/) do |node_names|
   @nodes = {}
 
   node_names.each_with_index do |name, i|
+    shift = (START_TIME - Time.now).to_i
     options = {
       image: "peercoinnet/#{available_nodes[i]}",
       links: @nodes.values.map(&:name),
       args: {
         debug: true,
-        timetravel: 30*24*3600,
+        timetravel: shift,
       },
     }
     node = CoinContainer.new(options)

--- a/src/test/features/step_definitions/revert_duplicate.rb
+++ b/src/test/features/step_definitions/revert_duplicate.rb
@@ -1,7 +1,14 @@
-When(/^node "(.*?)" sends a duplicate "(.*?)" of block "(.*?)"$/) do |node, duplicate, original|
+When(/^node "(.*?)" sends a duplicate "([^"]*?)" of block "([^"]*?)"$/) do |node, duplicate, original|
+  @blocks[duplicate] = @nodes[node].rpc("duplicateblock", @blocks[original])
+end
+
+When(/^node "(.*?)" sends a duplicate "([^"]*?)" of block "([^"]*?)" not received by node "(.*?)"$/) do |node, duplicate, original, other|
+  @nodes[other].rpc("ignorenextblock")
   @blocks[duplicate] = @nodes[node].rpc("duplicateblock", @blocks[original])
 end
 
 When(/^node "(.*?)" finds a block "(.*?)" on top of block "(.*?)"$/) do |node, block, parent|
   @blocks[block] = @nodes[node].generate_stake(@blocks[parent])
+  block_info = @nodes[node].rpc("getblock", @blocks[block])
+  expect(block_info["previousblockhash"]).to eq(@blocks[parent])
 end


### PR DESCRIPTION
These changes fix the behavior when the current best block's proof of stake is reused. It was not able to accept the block again when the node received a new block based on it. The fix is in commit 8f35648e6ba225b561311eec232767c0d6eed4d3.

The pull request also contains an important change about the proof of stake validity checking, in commit 367173b361351b7f4a72e30283eb1ce2de67a940.

The other commits are about older gcc compatibility and updates of the functional tests.