### PR TITLE
nullptr -> NULL: removing the dependency on a c++11 complient compiler

### DIFF
--- a/src/bignum.h
+++ b/src/bignum.h
@@ -52,7 +52,7 @@ public:
 class CBigNum
 {
 private:
-    BIGNUM *self = nullptr;
+    BIGNUM *self = NULL;
 
     void init()
     {


### PR DESCRIPTION
plz test if this fixes the issues building with old compilers