### PR TITLE
Show correct version number in debug window info

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -1,7 +1,7 @@
 TEMPLATE = app
 TARGET = peercoin-qt
 macx:TARGET = "Peercoin-Qt"
-VERSION = 0.4.0
+VERSION = 0.6.0
 INCLUDEPATH += src src/json src/qt
 QT += network core widgets
 DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE


### PR DESCRIPTION
This should hopefully show v.0.6.0 in the information tab in the debug window.