### PR TITLE
Changed color of text in status bar

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -204,6 +204,7 @@ void BitcoinGUI::createActions()
 
     mintingAction = new QAction(QIcon(":/icons/history"), tr("&Minting"), this);
     mintingAction->setToolTip(tr("Show your minting capacity"));
+    mintingAction->setToolTip(mintingAction->statusTip());
     mintingAction->setCheckable(true);
     mintingAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));
     tabGroup->addAction(mintingAction);

--- a/src/qt/res/themes/default.qss
+++ b/src/qt/res/themes/default.qss
@@ -164,6 +164,7 @@ QToolBar > QToolButton {
 
 /* Status Bar */
 QStatusBar {
+    color: #ffffff;
     background: #333333;
     border-top: 1px solid #e1e1e1;
 }
@@ -174,6 +175,7 @@ QStatusBar QLabel {
 }
 
 QStatusBar::item {
+    color: #ffffff;
     border: none;
 }
 


### PR DESCRIPTION
Changed color of text in status bar from gray to white since it was a bit hard to see. Text is shown when you hover over the buttons in the tool bar. I have tested this and it works.