### PR TITLE
Fix for no text shown in status bar when hovering minting button

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -203,7 +203,7 @@ void BitcoinGUI::createActions()
     tabGroup->addAction(historyAction);
 
     mintingAction = new QAction(QIcon(":/icons/history"), tr("&Minting"), this);
-    mintingAction->setToolTip(tr("Show your minting capacity"));
+    mintingAction->setStatusTip(tr("Show your minting capacity"));
     mintingAction->setToolTip(mintingAction->statusTip());
     mintingAction->setCheckable(true);
     mintingAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));


### PR DESCRIPTION
Fix for no text is shown in status bar when you hover over the minting button with your mouse.
I have tested this and it works.

Ref: https://github.com/peercoin/peercoin/issues/182