### PR TITLE
updates for win build on linux via MXE: qt and daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ ppcoin-qt
 peercoin-qt
 PPCoin-Qt.app
 Peercoin-Qt.app
+.qmake.stash
+peercoin-qt_plugin_import.cpp
 
 # Unit-tests
 Makefile.test
@@ -37,6 +39,11 @@ qrc_*.cpp
 # Mac specific
 .DS_Store
 build
+
+# mingw / Windows
+release/
+*.Debug
+*.Release
 
 !src/leveldb-*/Makefile
 peercoin-qt

--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -54,7 +54,7 @@ win32:QMAKE_LFLAGS *= -Wl,--large-address-aware
 contains(USE_QRCODE, 1) {
     message(Building with QRCode support)
     DEFINES += USE_QRCODE
-    LIBS += -lqrencode
+    LIBS += -lqrencode -lpng
 }
 
 # use: qmake "USE_UPNP=1" ( enabled by default; default)
@@ -108,7 +108,7 @@ LIBS += $$PWD/src/leveldb/libleveldb.a $$PWD/src/leveldb/libmemenv.a
     isEmpty(QMAKE_RANLIB) {
         QMAKE_RANLIB = $$replace(QMAKE_STRIP, strip, ranlib)
     }
-    LIBS += -lshlwapi
+    LIBS += -lshlwapi -lz -pthread
     genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX TARGET_OS=OS_WINDOWS_CROSSCOMPILE $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libleveldb.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libmemenv.a
 }
 genleveldb.target = $$PWD/src/leveldb/libleveldb.a

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -80,9 +80,11 @@ USE_IPV6:=1
 
 DEPSDIR?=/usr/local
 BOOST_SUFFIX?=-mgw46-mt-sd-1_52
+BOOST_THREAD_SUFFIX?=$BOOST_SUFFIX
 
 INCLUDEPATHS= \
  -I"$(CURDIR)" \
+ -I"$(CURDIR)/leveldb/include" \
  -I"$(DEPSDIR)/include"
 
 LIBPATHS= \
@@ -95,17 +97,18 @@ LIBS= \
  -l boost_system$(BOOST_SUFFIX) \
  -l boost_filesystem$(BOOST_SUFFIX) \
  -l boost_program_options$(BOOST_SUFFIX) \
- -l boost_thread$(BOOST_SUFFIX) \
+ -l boost_thread$(BOOST_THREAD_SUFFIX) \
  -l boost_chrono$(BOOST_SUFFIX) \
  -l db_cxx \
  -l ssl \
  -l crypto
 
-DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
+RPATH=-Wl,-rpath,$(DEPSDIR)/lib
+DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS
 DEBUGFLAGS=-g
-CFLAGS=-mthreads -O2 -w -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
+CFLAGS=-mthreads -O2 -w -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS) $(RPATH) -std=c++11
 # enable: ASLR, DEP and large address aware
-LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -Wl,--large-address-aware
+LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -Wl,--large-address-aware -Wl,--export-all-symbols -Wl,--add-stdcall-alias -v
 
 TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
 
@@ -121,7 +124,7 @@ ifneq (${USE_IPV6}, -)
 	DEFS += -DUSE_IPV6=$(USE_IPV6)
 endif
 
-LIBS += -l mingwthrd -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l winmm -l shell32 -l comctl32 -l ole32 -l oleaut32 -l uuid -l rpcrt4 -l advapi32 -l ws2_32 -l mswsock -l shlwapi
+LIBS += -l mingwthrd -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l winmm -l shell32 -l comctl32 -l ole32 -l oleaut32 -l uuid -l rpcrt4 -l advapi32 -l ws2_32 -l mswsock -l shlwapi -lz -pthread
 
 # TODO: make the mingw builds smarter about dependencies, like the linux/osx builds are
 HEADERS = $(wildcard *.h)


### PR DESCRIPTION
These are the code changed i needed to make to build the Windows exes using MXE on Ubuntu Linux 14.04 and 16.04

I have an update to the peercoin-qt.exe using MXE wiki, but i wanted to get this patch accepted before making an update (see below for additional windows qrencode support). I also have notes on building peercoind.exe with MXE to submit for review. 

#### Compile libqrencode

MXE does not provide the script for libqrencode, but there is a qrencode.mk pull request pending. https://github.com/mxe/mxe/pull/1890

To use, download to your local mxe/src/ directory. 

> cd src
> wget https://raw.githubusercontent.com/nohea/mxe/qrencode-add/src/qrencode.mk
> cd ..

Run `make qrencode` just like the supported packages:
> make qrencode

libqrencode will be built in your mxe installation, and you may pass the `"USE_QRCODE=1"` parameter to include QR code support in the qmake-qt5 command later. 
