### PR TITLE
[issue#202] Helpful Help menu links to chat and forum.

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -263,6 +263,12 @@ void BitcoinGUI::createActions()
     openRPCConsoleAction = new QAction(QIcon(":/icons/debugwindow"), tr("&Debug window"), this);
     openRPCConsoleAction->setStatusTip(tr("Open debugging and diagnostic console"));
 
+    openChatroomAction = new QAction(QIcon(":/icons/peercoin"), tr("&Chatroom"), this);
+    openChatroomAction->setStatusTip(tr("Open https://peercoin.chat in a web browser."));
+
+    openForumAction = new QAction(QIcon(":/icons/peercoin"), tr("&Forum"), this);
+    openForumAction->setStatusTip(tr("Open https://talk.peercoin.net in a web browser."));
+
     connect(quitAction, SIGNAL(triggered()), qApp, SLOT(quit()));
     connect(aboutAction, SIGNAL(triggered()), this, SLOT(aboutClicked()));
     connect(aboutQtAction, SIGNAL(triggered()), qApp, SLOT(aboutQt()));
@@ -274,6 +280,8 @@ void BitcoinGUI::createActions()
     connect(changePassphraseAction, SIGNAL(triggered()), walletFrame, SLOT(changePassphrase()));
     connect(signMessageAction, SIGNAL(triggered()), this, SLOT(gotoSignMessageTab()));
     connect(verifyMessageAction, SIGNAL(triggered()), this, SLOT(gotoVerifyMessageTab()));
+    connect(openChatroomAction, SIGNAL(triggered()), this, SLOT(openChatroom()));
+    connect(openForumAction, SIGNAL(triggered()), this, SLOT(openForum()));
 }
 
 void BitcoinGUI::createMenuBar()
@@ -303,6 +311,8 @@ void BitcoinGUI::createMenuBar()
 
     QMenu *help = appMenuBar->addMenu(tr("&Help"));
     help->addAction(openRPCConsoleAction);
+    help->addAction(openChatroomAction);
+    help->addAction(openForumAction);
     help->addSeparator();
     help->addAction(aboutAction);
     help->addAction(aboutQtAction);
@@ -349,6 +359,8 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
 
             toggleHideAction->setIcon(QIcon(":/icons/toolbar_testnet"));
             aboutAction->setIcon(QIcon(":/icons/toolbar_testnet"));
+            openChatroomAction->setIcon(QIcon(":/icons/toolbar_testnet"));
+            openForumAction->setIcon(QIcon(":/icons/toolbar_testnet"));
         }
 
         // Create system tray menu (or setup the dock menu) that late to prevent users from calling actions,
@@ -522,6 +534,14 @@ void BitcoinGUI::gotoSignMessageTab(QString addr)
 void BitcoinGUI::gotoVerifyMessageTab(QString addr)
 {
     if (walletFrame) walletFrame->gotoVerifyMessageTab(addr);
+}
+
+void BitcoinGUI::openChatroom() {
+    QDesktopServices::openUrl(QUrl("https://peercoin.chat"));
+}
+
+void BitcoinGUI::openForum() {
+    QDesktopServices::openUrl(QUrl("https://talk.peercoin.net"));
 }
 
 void BitcoinGUI::setNumConnections(int count)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -1,6 +1,7 @@
 #ifndef BITCOINGUI_H
 #define BITCOINGUI_H
 
+#include <QDesktopServices>
 #include <QMainWindow>
 #include <QSystemTrayIcon>
 #include <QMap>
@@ -106,6 +107,8 @@ private:
     QAction *changePassphraseAction;
     QAction *aboutQtAction;
     QAction *openRPCConsoleAction;
+    QAction *openChatroomAction;
+    QAction *openForumAction;
 
     QSystemTrayIcon *trayIcon;
     Notificator *notificator;
@@ -188,6 +191,11 @@ private slots:
     void optionsClicked();
     /** Show about dialog */
     void aboutClicked();
+
+    // Open chatroom / forum URL in the system's browser.
+    void openChatroom();
+    void openForum();
+
 #ifndef Q_OS_MAC
     /** Handle tray icon clicked */
     void trayIconActivated(QSystemTrayIcon::ActivationReason reason);

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -335,12 +335,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Sign &amp;message...</translation>
     </message>
     <message>
-        <location line="+293"/>
+        <location line="+313"/>
         <source>Synchronizing with network...</source>
         <translation>Synchronizing with network...</translation>
     </message>
     <message>
-        <location line="-374"/>
+        <location line="-394"/>
         <source>&amp;Overview</source>
         <translation>&amp;Overview</translation>
     </message>
@@ -415,7 +415,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Change Passphrase...</translation>
     </message>
     <message>
-        <location line="+298"/>
+        <location line="+318"/>
         <source>Importing blocks from disk...</source>
         <translation>Importing blocks from disk...</translation>
     </message>
@@ -425,7 +425,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Reindexing blocks on disk...</translation>
     </message>
     <message>
-        <location line="-372"/>
+        <location line="-392"/>
         <source>Send coins to a Peercoin address</source>
         <translation>Send coins to a Peercoin address</translation>
     </message>
@@ -461,12 +461,12 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="-184"/>
-        <location line="+562"/>
+        <location line="+582"/>
         <source>Peercoin</source>
         <translation>Peercoin</translation>
     </message>
     <message>
-        <location line="-562"/>
+        <location line="-582"/>
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
@@ -536,7 +536,27 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Verify messages to ensure they were signed with specified Peercoin addresses</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+5"/>
+        <source>&amp;Chatroom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open https://peercoin.chat in a web browser.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Forum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open https://talk.peercoin.net in a web browser.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+28"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
@@ -551,7 +571,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+14"/>
         <source>Tabs toolbar</source>
         <translation>Tabs toolbar</translation>
     </message>
@@ -562,12 +582,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="+47"/>
+        <location line="+49"/>
         <source>Peercoin client</source>
         <translation>Peercoin client</translation>
     </message>
     <message numerus="yes">
-        <location line="+146"/>
+        <location line="+154"/>
         <source>%n active connection(s) to Peercoin network</source>
         <translation>
             <numerusform>%n active connection to Peercoin network</numerusform>
@@ -2881,7 +2901,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Peercoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH)</source>
         <translation type="unfinished">Acceptable ciphers (default: TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH)</translation>
     </message>


### PR DESCRIPTION
hallo peercoin people! @peerchemist @backpacker69 @Sentinelrv 

This idea: https://github.com/peercoin/peercoin/issues/202

A couple of menu items in the Help menu that will open peercoin chat / forum :) I grabbed the "external_link" icon from wiki commons ( https://commons.wikimedia.org/wiki/File:External_link_icon.png ) as a stand-in ... although i kind of like the little globe :earth_africa: 