### PR TITLE
Change getblock rpc interface to be closer to recent bitcoind

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1376,6 +1376,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "getbalance"             && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "getblockhash"           && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "getblock"               && n > 1) ConvertTo<bool>(params[1]);
+    if (strMethod == "getblock"               && n > 2) ConvertTo<bool>(params[2]);
     if (strMethod == "move"                   && n > 2) ConvertTo<double>(params[2]);
     if (strMethod == "move"                   && n > 3) ConvertTo<boost::int64_t>(params[3]);
     if (strMethod == "sendfrom"               && n > 2) ConvertTo<double>(params[2]);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -160,9 +160,10 @@ Value getbestblockhash(const Array& params, bool fHelp)
 
 Value getblock(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
+    if (fHelp || params.size() < 1 || params.size() > 3)
         throw runtime_error(
-            "getblock <hash> [txinfo]\n"
+            "getblock <hash> [verbose] [txinfo]\n"
+            "verbose optional (default true) if false output hash like bitcoin-cli\n"
             "txinfo optional to print more detailed tx info\n"
             "Returns details of a block with given block-hash.");
 
@@ -176,7 +177,24 @@ Value getblock(const Array& params, bool fHelp)
     CBlockIndex* pblockindex = mapBlockIndex[hash];
     block.ReadFromDisk(pblockindex);
 
-    return blockToJSON(block, pblockindex, params.size() > 1 ? params[1].get_bool() : false);
+    bool fTxinfo = false;
+    if (params.size() > 2)
+      fTxinfo = params[2].get_bool();
+
+    // bitcoin-cli verbose=0 support
+    bool fVerbose = true;
+    if (params.size() > 1)
+      fVerbose = params[1].get_bool();
+
+    if (!fVerbose)
+      {
+        CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
+        ssBlock << block;
+	std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
+        return strHex;
+      }
+ 
+    return blockToJSON(block, pblockindex, fTxinfo);
 }
 
 Value gettxoutsetinfo(const Array& params, bool fHelp)


### PR DESCRIPTION
This patch moves the 2nd parameter [txinfo] to the 3rd paramter.
The 2nd parameter of getblock becomes [verbose] which allows the raw getblock output, with full info.
One use case is the bitcore-node server, which expects it from bitcoind.

This could be a breaking change for Peercoin. In that case,
the [verbose] param could be just added as a 3rd parameter.