### PR TITLE
Update README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -87,7 +87,7 @@ with each other, with the help of a P2P network to check for double-spending.
 Setup
 ---------------------
 You need the Qt4 run-time libraries to run Bitcoin-Qt. On Debian or Ubuntu:
-	`sudo apt-get install libqtgui4`
+	`sudo apt-get install libqtgui4 libqt4-network`
 
 Unpack the files into a directory and run:
 


### PR DESCRIPTION
Update setup section: libqt4-network is needed in addition to libqtgui4 (on current debian buster at least).