### PR TITLE
add -pthread to LIBS for MXE win32 build in bitcoin-qt.pro, fix for v0.6.2ppc.rc4

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -116,7 +116,7 @@ LIBS += $$PWD/src/leveldb/libleveldb.a $$PWD/src/leveldb/libmemenv.a
     isEmpty(QMAKE_RANLIB) {
         QMAKE_RANLIB = $$replace(QMAKE_STRIP, strip, ranlib)
     }
-    LIBS += -lshlwapi -lz
+    LIBS += -lshlwapi -lz -pthread
     genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX TARGET_OS=OS_WINDOWS_CROSSCOMPILE $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libleveldb.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libmemenv.a
 }
 genleveldb.target = $$PWD/src/leveldb/libleveldb.a


### PR DESCRIPTION
This is a tiny patch to fix the Windows QT build using MXE on Linux for for v0.6.2ppc.rc4

Fix was to add -pthread to LIBS in win32 build in bitcoin-qt.pro

This is the error before my patch:
```
$ /usr/local/mxe/usr/bin/i686-w64-mingw32.static-qmake-qt5 BOOST_LIB_SUFFIX=-mt BOOST_THREAD_LIB_SUFFIX=_win32-mt "QMAKE_CC=/usr/local/mxe/usr/bin/i686-w64-mingw32.static-gcc" "QMAKE_CXX=/usr/local/mxe/usr/bin/i686-w64-mingw32.static-g++" "OPENSSL_INCLUDE_PATH=/usr/local/mxe/usr/i686-w64-mingw32.static/include" "OPENSSL_LIB_PATH=/usr/local/mxe/usr/i686-w64-mingw32.static/lib" "BDB_INCLUDE_PATH=/usr/local/mxe/usr/i686-w64-mingw32.static/include" "BDB_LIB_PATH=/usr/local/mxe/usr/i686-w64-mingw32.static/lib" "MINIUPNPC_INCLUDE_PATH=/usr/local/mxe/usr/i686-w64-mingw32.static/include" "MINIUPNPC_LIB_PATH=/usr/local/mxe/usr/i686-w64-mingw32.static/lib" "QMAKE_CXXFLAGS=-std=c++11 -DBOOST_NO_CXX11_SCOPED_ENUMS" "QMAKE_RANLIB=/usr/local/mxe/usr/bin/i686-w64-mingw32.static-ranlib" "QMAKE_LRELEASE=/usr/local/mxe/usr/i686-w64-mingw32.static/qt5/bin/lrelease" "AR=/usr/local/mxe/usr/bin/i686-w64-mingw32.static-ar" "USE_UPNP=0" "USE_QRCODE=1" "STATIC=1" bitcoin-qt.pro

...
i686-w64-mingw32.static-g++ -Wl,--dynamicbase -Wl,--nxcompat -Wl,-s -Wl,-subsystem,windows -mthreads -o release/peercoin-qt.exe object_script.peercoin-qt.Release  -lmingwthrd -lmingw32 -L/usr/local/mxe/usr/i686-w64-mingw32.static/qt5/lib /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/lib/libqtmain.a -lqrencode -lpng -L/usr/local/mxe/usr/i686-w64-mingw32.static/lib -lminiupnpc /home/username/code/peercoin/peercoin/src/leveldb/libleveldb.a /home/username/code/peercoin/peercoin/src/leveldb/libmemenv.a -ldb_cxx -lmswsock -lboost_system-mt -lboost_filesystem-mt -lboost_program_options-mt -lboost_thread_win32-mt -lboost_chrono-mt -L/usr/local/mxe/usr/i686-w64-mingw32.static/qt5/plugins/platforms /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/plugins/platforms/libqwindows.a -lwinspool /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/lib/libQt5EventDispatcherSupport.a -L/usr/local/mxe/usr/i686-w64-mingw32.static/lib /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/lib/libQt5AccessibilitySupport.a /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/lib/libQt5FontDatabaseSupport.a /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/lib/libQt5ThemeSupport.a -L/usr/local/mxe/usr/i686-w64-mingw32.static/qt5/plugins/imageformats /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/plugins/imageformats/libqgif.a /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/plugins/imageformats/libqico.a /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/plugins/imageformats/libqjpeg.a -ljpeg -L/usr/local/mxe/usr/i686-w64-mingw32.static/qt5/plugins/bearer /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/plugins/bearer/libqgenericbearer.a /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/plugins/bearer/libqnativewifibearer.a /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/lib/libQt5Widgets.a -luxtheme -ldwmapi /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/lib/libQt5Gui.a -lcomdlg32 -loleaut32 -limm32 -lopengl32 -lharfbuzz -lcairo -lgobject-2.0 -lfontconfig -lusp10 -lmsimg32 -lpixman-1 -lffi -lexpat -lfreetype -lbz2 -lpng16 -lharfbuzz_too -lfreetype_too -lglib-2.0 -lshlwapi -lpcre -lintl -liconv /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/lib/libQt5Network.a -ldnsapi -liphlpapi -lssl -lcrypto -lgdi32 -lcrypt32 /usr/local/mxe/usr/i686-w64-mingw32.static/qt5/lib/libQt5Core.a -lole32 -luuid -lws2_32 -ladvapi32 -lshell32 -luser32 -lkernel32 -lmpr -lversion -lwinmm -lz -lpcre2-16 build/bitcoin-qt-res_res.o
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(qrspec.o):qrspec.c:(.text+0x948): undefined reference to `pthread_mutex_lock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(qrspec.o):qrspec.c:(.text+0x979): undefined reference to `pthread_mutex_unlock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(qrspec.o):qrspec.c:(.text+0xa05): undefined reference to `pthread_mutex_lock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(qrspec.o):qrspec.c:(.text+0xa44): undefined reference to `pthread_mutex_unlock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(rscode.o):rscode.c:(.text+0x49f): undefined reference to `pthread_mutex_lock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(rscode.o):rscode.c:(.text+0x565): undefined reference to `pthread_mutex_unlock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(rscode.o):rscode.c:(.text+0x5ba): undefined reference to `pthread_mutex_lock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(rscode.o):rscode.c:(.text+0x5fa): undefined reference to `pthread_mutex_unlock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(mqrspec.o):mqrspec.c:(.text+0x395): undefined reference to `pthread_mutex_lock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(mqrspec.o):mqrspec.c:(.text+0x3c6): undefined reference to `pthread_mutex_unlock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(mqrspec.o):mqrspec.c:(.text+0x44e): undefined reference to `pthread_mutex_lock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libqrencode.a(mqrspec.o):mqrspec.c:(.text+0x48d): undefined reference to `pthread_mutex_unlock'
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libdb_cxx.a(os_pid.o):os_pid.c:(.text+0x25): undefined reference to `pthread_self'
collect2: error: ld returned 1 exit status
make[1]: *** [release/peercoin-qt.exe] Error 1
make[1]: Leaving directory `/home/username/code/peercoin/peercoin'
make: *** [release] Error 2
```

If i build with USE_QRCODE=0 i still get a build error:
```
/usr/local/mxe/usr/i686-w64-mingw32.static/lib/libdb_cxx.a(os_pid.o):os_pid.c:(.text+0x25): undefined reference to `pthread_self'
collect2: error: ld returned 1 exit status
make[1]: *** [release/peercoin-qt.exe] Error 1
make[1]: Leaving directory `/home/username/code/peercoin/peercoin'
make: *** [release] Error 2

```
