### PR TITLE
Fix for time on two separate lines in RPC console

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -320,7 +320,7 @@ void RPCConsole::message(int category, const QString &message, bool html)
     QTime time = QTime::currentTime();
     QString timeString = time.toString();
     QString out;
-    out += "<table><tr><td class=\"time\" width=\"65\">" + timeString + "</td>";
+    out += "<table><tr><td class=\"time\" width=\"70\">" + timeString + "</td>";
     out += "<td class=\"icon\" width=\"32\"><img src=\"" + categoryClass(category) + "\"></td>";
     out += "<td class=\"message " + categoryClass(category) + "\" valign=\"middle\">";
     if(html)


### PR DESCRIPTION
Fix for time displayed on two separate lines in the RPC console