### PR TITLE
replace boost sleep_for with std equivalent.

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -8,8 +8,7 @@ greaterThan(QT_MAJOR_VERSION, 4):QT+=widgets
 DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE HAVE_WORKING_BOOST_SLEEP_FOR
 CONFIG += no_include_pwd
 CONFIG += thread
-
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG += c++11
 
 # for boost 1.37, add -mt to the boost libraries
 # use: qmake BOOST_LIB_SUFFIX=-mt

--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -9,6 +9,8 @@ DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE HAVE_WORKING_BOOS
 CONFIG += no_include_pwd
 CONFIG += thread
 
+QMAKE_CXXFLAGS += -std=c++11
+
 # for boost 1.37, add -mt to the boost libraries
 # use: qmake BOOST_LIB_SUFFIX=-mt
 # for boost thread win32 with _win32 sufix

--- a/src/util.h
+++ b/src/util.h
@@ -24,6 +24,8 @@ typedef int pid_t; /* define for Windows compatibility */
 #include <utility>
 #include <vector>
 #include <string>
+#include <chrono>
+#include <thread>
 
 #include <boost/version.hpp>
 #include <boost/thread.hpp>
@@ -109,17 +111,7 @@ T* alignup(T* p)
 
 inline void MilliSleep(int64 n)
 {
-// Boost's sleep_for was uninterruptable when backed by nanosleep from 1.50
-// until fixed in 1.52. Use the deprecated sleep method for the broken case.
-// See: https://svn.boost.org/trac/boost/ticket/7238
-#if defined(HAVE_WORKING_BOOST_SLEEP_FOR)
-    boost::this_thread::sleep_for(boost::chrono::milliseconds(n));
-#elif defined(HAVE_WORKING_BOOST_SLEEP)
-    boost::this_thread::sleep(boost::posix_time::milliseconds(n));
-#else
-  //should never get here
-#error missing boost sleep implementation
-#endif
+    std::this_thread::sleep_for(std::chrono::milliseconds(n));
 }
 
 #ifndef THROW_WITH_STACKTRACE


### PR DESCRIPTION
This should solve a linking error when compiling against a recent version of boost (1.68).