### PR TITLE
Refactorize `kernel.cpp`.

### DIFF
--- a/src/bignum.h
+++ b/src/bignum.h
@@ -8,6 +8,9 @@
 #include <stdexcept>
 #include <vector>
 #include <openssl/bn.h>
+#include <uint256.h>
+#include <version.h>
+#include <serialize.h>
 
 /** Errors thrown by the bignum class */
 class bignum_error : public std::runtime_error

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -78,7 +78,7 @@ using ExtPubKey = std::array<unsigned char, 4>;
 
 static const std::array<ExtPubKey, nNetworks> ExtPubKeys{{
     {0x04, 0x88, 0xB2, 0x1E}, // Main
-    {0x04, 0x35, 0x83, 0x9F}  // Test
+    {0x04, 0x35, 0x87, 0xCF}  // Test
 }};
 
 Network DetectNetwork(const CChainParams& params)
@@ -216,7 +216,7 @@ struct SelectionBlock {
     bool operator<(const SelectionBlock& x) const
     {
         auto t1 = GetTime(), t2 = x.GetTime();
-        return t1 != t2 ? t1 < t2 : pindex->GetBlockHash() < x.pindex->GetBlockHash();
+        return t1 != t2 ? t1 < t2 : pindex->GetBlockHash().ReversedLess(x.pindex->GetBlockHash());
     }
 };
 
@@ -621,25 +621,6 @@ bool State::CheckCoinStake(CoinStake& coinStake, uint256& hashProofOfStake, bool
 
     return true;
 }
-
-/*
-bool State::CheckProofOfStake(CValidationState& state, const CTransactionRef& tx, unsigned int nBits, uint256& hashProofOfStake) const
-{
-    static char const* function = "Kernel::State::CheckProofOfStake";
-
-    CoinStake coinStake;
-    coinStake.nBits = nBits;
-
-    if (!coinStake.Load(tx))
-        return error("%s(): could not load coin stake tx.", function);
-
-    bool fDoS = false;
-    if (!CheckCoinStake(coinStake, hashProofOfStake, &fDoS))
-        return fDoS && state.DoS(1);
-
-    return true;
-}
-*/
 
 // V0.3: Stake modifier used to hash for a stake kernel is chosen as the stake
 // modifier about a selection interval later than the coin generating the kernel

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -2,194 +2,333 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <kernel.h>
+#include <algorithm>
+#include <bignum.h>
 #include <chainparams.h>
-#include <util.h>
-#include <validation.h>
+#include <consensus/validation.h>
+#include <kernel.h>
+#include <random.h>
 #include <streams.h>
 #include <timedata.h>
-#include <bignum.h>
 #include <txdb.h>
-#include <consensus/validation.h>
-#include <random.h>
+#include <util.h>
+#include <validation.h>
 
-#include <boost/assign/list_of.hpp>
+namespace Kernel
+{
 
-using namespace std;
+using Consensus::Params;
 
-// Protocol switch time of v0.3 kernel protocol
-unsigned int nProtocolV03SwitchTime     = 1363800000;
-unsigned int nProtocolV03TestSwitchTime = 1359781000;
-// Protocol switch time of v0.4 kernel protocol
-unsigned int nProtocolV04SwitchTime     = 1399300000;
-unsigned int nProtocolV04TestSwitchTime = 1395700000;
-// Protocol switch time of v0.5 kernel protocol
-unsigned int nProtocolV05SwitchTime     = 1461700000;
-unsigned int nProtocolV05TestSwitchTime = 1447700000;
-// Protocol switch time of v0.6 kernel protocol
-// supermajority hardfork: actual fork will happen later than switch time
-const unsigned int nProtocolV06SwitchTime     = 1513050000; // Tue 12 Dec 03:40:00 UTC 2017
-const unsigned int nProtocolV06TestSwitchTime = 1508198400; // Tue 17 Oct 00:00:00 UTC 2017
-// Protocol switch time for 0.7 kernel protocol
-const unsigned int nProtocolV07SwitchTime     = 1552392000; // Tue 12 Mar 12:00:00 UTC 2019
-const unsigned int nProtocolV07TestSwitchTime = 1541505600; // Tue 06 Nov 12:00:00 UTC 2018
+// Factored out to avoid repetition.
+struct DebugFlags {
+    bool fDebug;
+    bool fPrintStakeModifier;
+
+    DebugFlags()
+    {
+        fDebug = gArgs.GetBoolArg("-debug", false) || gArgs.GetBoolArg("-kerneldebug", false);
+        fPrintStakeModifier = gArgs.GetBoolArg("-printstakemodifier", false);
+    }
+};
+
+// protocols
+
+// Rationale:
+// * Protocol version detection can be factored out.
+// * Version-dependent branches use comparison operators.
+// * Switch times can be neatly organized into a 2D table.
+
+enum struct Protocol : size_t {
+    V02, V03, V04, V05, V06, V07,
+    Invalid // keep last
+};
+
+constexpr auto nProtocols = static_cast<size_t>(Protocol::Invalid);
+
+constexpr bool operator<(Protocol p1, Protocol p2)
+{
+    return static_cast<size_t>(p1) < static_cast<size_t>(p2);
+}
+
+constexpr bool operator>=(Protocol p1, Protocol p2)
+{
+    return static_cast<size_t>(p1) >= static_cast<size_t>(p2);
+}
+
+static const std::array<char const*, nProtocols> ProtocolNames{{
+    "v0.2", "v0.3", "v0.4", "v0.5", "v0.6", "v0.7"
+}};
+
+constexpr char const* ProtocolName(Protocol p)
+{
+    return p < Protocol::Invalid ? ProtocolNames[static_cast<size_t>(p)] : "v???";
+}
+
+// networks
+
+enum struct Network : size_t {
+    Main,
+    Test,
+    Invalid // keep last
+};
+
+constexpr auto nNetworks = static_cast<size_t>(Network::Invalid);
+
+using ExtPubKey = std::array<unsigned char, 4>;
+
+static const std::array<ExtPubKey, nNetworks> ExtPubKeys{{
+    {0x04, 0x88, 0xB2, 0x1E}, // Main
+    {0x04, 0x35, 0x83, 0x9F}  // Test
+}};
+
+Network DetectNetwork(const CChainParams& params)
+{
+    auto epkIt = params.Base58Prefix(CChainParams::EXT_PUBLIC_KEY).begin();
+    for (size_t k = 0u; k < nNetworks; ++k) {
+        auto& epk = ExtPubKeys[k];
+        if (std::equal(epk.begin(), epk.end(), epkIt))
+            return static_cast<Network>(k);
+    }
+    return Network::Invalid;
+}
+
+// protocol switch times
+
+static constexpr std::array<std::array<uint32_t, nNetworks>, nProtocols> SwitchTimes{{
+    {0, 0},                   // V02
+    {1363800000, 1359781000}, // V03
+    {1399300000, 1395700000}, // V04
+    {1461700000, 1447700000}, // V05
+    {1513050000, 1508198400}, // V06
+    {1552392000, 1541505600}, // V07
+}};
+
+constexpr uint32_t GetSwitchTime(Network network, Protocol protocol)
+{
+    return SwitchTimes[static_cast<size_t>(protocol)][static_cast<size_t>(network)];
+}
 
 // Switch time for new BIPs from bitcoin 0.16.x
 const uint32_t nBTC16BIPsSwitchTime = 1559260800; // Fri 31 May 00:00:00 UTC 2019
 
-// Hard checkpoints of stake modifiers to ensure they are deterministic
-static std::map<int, unsigned int> mapStakeModifierCheckpoints =
-    boost::assign::map_list_of
-    ( 0, 0x0e00670bu )
-    ( 19080, 0xad4e4d29u )
-    ( 30583, 0xdc7bf136u )
-    ( 99999, 0xf555cfd2u )
-    (219999, 0x91b7444du )
-    (336000, 0x6c3c8048u )
-    (371850, 0x9b850bdfu )
-    (407813, 0x46fe50b5u )
-    ;
+// checkpoints
 
-static std::map<int, unsigned int> mapStakeModifierTestnetCheckpoints =
-    boost::assign::map_list_of
-    ( 0, 0x0e00670bu )
-    ( 19080, 0x3711dc3au )
-    ( 30583, 0xb480fadeu )
-    ( 99999, 0x9a62eaecu )
-    (219999, 0xeafe96c3u )
-    (336000, 0x8330dc09u )
-    (372751, 0xafb94e2fu )
-    (382019, 0x7f5cf5ebu )
-    ;
+// Hard checkpoints of stake modifiers to ensure they are deterministic.
 
-// Whether the given coinstake is subject to new v0.3 protocol
-bool IsProtocolV03(unsigned int nTimeCoinStake)
+struct Checkpoint {
+    int nHeight;
+    uint32_t nChecksum;
+};
+
+static constexpr Checkpoint checkpointsMain[] = {
+    {       0, 0x0e00670bu },
+    {   19080, 0xad4e4d29u },
+    {   30583, 0xdc7bf136u },
+    {   99999, 0xf555cfd2u },
+    {  219999, 0x91b7444du },
+    {  336000, 0x6c3c8048u },
+    {  371850, 0x9b850bdfu },
+    {  407813, 0x46fe50b5u },
+    {-1, 0} // Sentinel
+};
+
+static constexpr Checkpoint checkpointsTest[] = {
+    {       0, 0x0e00670bu },
+    {   19080, 0x3711dc3au },
+    {   30583, 0xb480fadeu },
+    {   99999, 0x9a62eaecu },
+    {  219999, 0xeafe96c3u },
+    {  336000, 0x8330dc09u },
+    {  372751, 0xafb94e2fu },
+    {  382019, 0x7f5cf5ebu },
+    {-1, 0} // Sentinel
+};
+
+static constexpr std::array<Checkpoint const*, nNetworks> checkpoints{{
+    checkpointsMain, checkpointsTest
+}};
+
+bool CheckStakeModifierChecksum(Network network, int nHeight, uint32_t nChecksum)
 {
-    return (nTimeCoinStake >= (Params().NetworkIDString() == CBaseChainParams::TESTNET ? nProtocolV03TestSwitchTime : nProtocolV03SwitchTime));
+    Checkpoint const* pCheckpoint = checkpoints[static_cast<size_t>(network)];
+    while (pCheckpoint->nHeight != -1 && pCheckpoint->nHeight < nHeight) ++pCheckpoint;
+    return pCheckpoint->nHeight != nHeight || pCheckpoint->nChecksum == nChecksum;
 }
 
-// Whether the given block is subject to new v0.4 protocol
-bool IsProtocolV04(unsigned int nTimeBlock)
+// selection params
+
+// The selection interval is partitioned into 64 sections, whose durations
+// depend on the modifier interval. This structure computes all the section
+// durations and their sum, and caches the results.
+
+struct SelectionParams {
+    int64_t nInterval;
+    int64_t nIntervalSections[64];
+
+    SelectionParams(const Params&);
+};
+
+SelectionParams::SelectionParams(const Params& params)
 {
-    return (nTimeBlock >= (Params().NetworkIDString() == CBaseChainParams::TESTNET ? nProtocolV04TestSwitchTime : nProtocolV04SwitchTime));
-}
-
-// Whether the given transaction is subject to new v0.5 protocol
-bool IsProtocolV05(unsigned int nTimeTx)
-{
-    return (nTimeTx >= (Params().NetworkIDString() == CBaseChainParams::TESTNET ? nProtocolV05TestSwitchTime : nProtocolV05SwitchTime));
-}
-
-// Whether a given block is subject to new v0.6 protocol
-// Test against previous block index! (always available)
-bool IsProtocolV06(const CBlockIndex* pindexPrev)
-{
-  if (pindexPrev->nTime < (Params().NetworkIDString() == CBaseChainParams::TESTNET ? nProtocolV06TestSwitchTime : nProtocolV06SwitchTime))
-    return false;
-
-  // if 900 of the last 1,000 blocks are version 2 or greater (90/100 if testnet):
-  // Soft-forking PoS can be dangerous if the super majority is too low
-  // The stake majority will decrease after the fork
-  // since only coindays of updated nodes will get destroyed.
-  if ((Params().NetworkIDString() != CBaseChainParams::TESTNET && IsSuperMajority(2, pindexPrev, 900, 1000)) ||
-      (Params().NetworkIDString() == CBaseChainParams::TESTNET && IsSuperMajority(2, pindexPrev, 90, 100)))
-    return true;
-
-  return false;
-}
-
-// Whether a given transaction is subject to new v0.7 protocol
-bool IsProtocolV07(unsigned int nTimeTx)
-{
-    bool fTestNet = Params().NetworkIDString() == CBaseChainParams::TESTNET;
-    return (nTimeTx >= (fTestNet? nProtocolV07TestSwitchTime : nProtocolV07SwitchTime));
-}
-
-bool IsBTC16BIPsEnabled(uint32_t nTimeTx)
-{
-    return nTimeTx >= nBTC16BIPsSwitchTime;
-}
-
-// Get the last stake modifier and its generation time from a given block
-static bool GetLastStakeModifier(const CBlockIndex* pindex, uint64_t& nStakeModifier, int64_t& nModifierTime)
-{
-    if (!pindex)
-        return error("GetLastStakeModifier: null pindex");
-    while (pindex && pindex->pprev && !pindex->GeneratedStakeModifier())
-        pindex = pindex->pprev;
-    if (!pindex->GeneratedStakeModifier())
-        return error("GetLastStakeModifier: no generation at genesis block");
-    nStakeModifier = pindex->nStakeModifier;
-    nModifierTime = pindex->GetBlockTime();
-    return true;
-}
-
-// Get selection interval section (in seconds)
-static int64_t GetStakeModifierSelectionIntervalSection(int nSection)
-{
-    assert (nSection >= 0 && nSection < 64);
-    return (Params().GetConsensus().nModifierInterval * 63 / (63 + ((63 - nSection) * (MODIFIER_INTERVAL_RATIO - 1))));
-}
-
-// Get stake modifier selection interval (in seconds)
-static int64_t GetStakeModifierSelectionInterval()
-{
-    int64_t nSelectionInterval = 0;
-    for (int nSection=0; nSection<64; nSection++)
-        nSelectionInterval += GetStakeModifierSelectionIntervalSection(nSection);
-    return nSelectionInterval;
-}
-
-// select a block from the candidate blocks in vSortedByTimestamp, excluding
-// already selected blocks in vSelectedBlocks, and with timestamp up to
-// nSelectionIntervalStop.
-static bool SelectBlockFromCandidates(
-    vector<pair<int64_t, uint256> >& vSortedByTimestamp,
-    map<uint256, const CBlockIndex*>& mapSelectedBlocks,
-    int64_t nSelectionIntervalStop, uint64_t nStakeModifierPrev,
-    const CBlockIndex** pindexSelected)
-{
-    bool fSelected = false;
-    arith_uint256 hashBest = 0;
-    *pindexSelected = (const CBlockIndex*) 0;
-    for (const auto& item : vSortedByTimestamp)
-    {
-        if (!mapBlockIndex.count(item.second))
-            return error("SelectBlockFromCandidates: failed to find block index for candidate block %s", item.second.ToString());
-        const CBlockIndex* pindex = mapBlockIndex[item.second];
-        if (fSelected && pindex->GetBlockTime() > nSelectionIntervalStop)
-            break;
-        if (mapSelectedBlocks.count(pindex->GetBlockHash()) > 0)
-            continue;
-        // compute the selection hash by hashing its proof-hash and the
-        // previous proof-of-stake modifier
-        uint256 hashProof = pindex->IsProofOfStake()? pindex->hashProofOfStake : pindex->GetBlockHash();
-        CDataStream ss(SER_GETHASH, 0);
-        ss << hashProof << nStakeModifierPrev;
-        arith_uint256 hashSelection = UintToArith256(Hash(ss.begin(), ss.end()));
-        // the selection hash is divided by 2**32 so that proof-of-stake block
-        // is always favored over proof-of-work block. this is to preserve
-        // the energy efficiency property
-        if (pindex->IsProofOfStake())
-            hashSelection >>= 32;
-        if (fSelected && hashSelection < hashBest)
-        {
-            hashBest = hashSelection;
-            *pindexSelected = (const CBlockIndex*) pindex;
-        }
-        else if (!fSelected)
-        {
-            fSelected = true;
-            hashBest = hashSelection;
-            *pindexSelected = (const CBlockIndex*) pindex;
-        }
+    nInterval = 0;
+    for (int64_t i = 0; i < 64; ++i) {
+        auto nDiv = 63 + (63 - i) * (MODIFIER_INTERVAL_RATIO - 1);
+        auto nSection = params.nModifierInterval * 63 / nDiv;
+        nIntervalSections[i] = nSection;
+        nInterval += nSection;
     }
-    if (gArgs.GetBoolArg("-debug", false) && gArgs.GetBoolArg("-printstakemodifier", false))
-        LogPrintf("SelectBlockFromCandidates: selection hash=%s\n", hashBest.ToString());
-    return fSelected;
 }
 
-// Stake Modifier (hash modifier of proof-of-stake):
+// selection
+
+// Candidate blocks are selected based on their block time and selection hash.
+// This structure caches the computed selection hash, and provides the required
+// lexicographic ordering by (block time, block hash).
+struct SelectionBlock {
+    const CBlockIndex* pindex;
+    arith_uint256 hashSelection;
+
+    // The selection hash depends on the previous stake modifier.
+    // Note that the stake modifier is the same for all candidates.
+    SelectionBlock(const CBlockIndex* pindex, uint64_t stakeModifier)
+        : pindex{pindex}
+    {
+        bool fPOS = pindex->IsProofOfStake();
+
+        // The other input varies with each candidate block.
+        uint256 hashProof = fPOS ? pindex->hashProofOfStake : pindex->GetBlockHash();
+
+        CDataStream ss{SER_GETHASH, 0};
+        ss << hashProof << stakeModifier;
+        hashSelection = UintToArith256(Hash(ss.begin(), ss.end()));
+
+        // In order to preserve the energy efficiency property, selection favors
+        // proof-of-stake candidates over proof-of-work ones. The selected
+        // candidate in each round is the one with the smallest selection hash,
+        // which will almost always be a proof-of-stake block if there are any.
+        if (fPOS) hashSelection >>= 32u;
+    }
+
+    int64_t GetTime() const {
+        return pindex->GetBlockTime();
+    }
+
+    bool operator<(const SelectionBlock& x) const
+    {
+        auto t1 = GetTime(), t2 = x.GetTime();
+        return t1 != t2 ? t1 < t2 : pindex->GetBlockHash() < x.pindex->GetBlockHash();
+    }
+};
+
+struct Selection {
+    const Params& params;
+    const SelectionParams& selParams;
+
+    std::vector<SelectionBlock> vBlocks;
+    int64_t nTimeStart;
+    int64_t nTimeStop;
+
+    Selection(const Params& params, const SelectionParams& selParams)
+        : params{params}, selParams{selParams}
+    {
+        vBlocks.reserve(64 * params.nModifierInterval / params.nStakeTargetSpacing);
+        nTimeStart = nTimeStop = 0;
+    }
+
+
+    void Collect(const CBlockIndex* pindex, uint64_t stakeModifier);
+    void Select();
+    uint64_t ComputeModifier() const;
+
+    void Log() const;
+};
+
+template <typename T>
+T RoundDown(T nValue, T nDivisor)
+{
+    return (nValue / nDivisor) * nDivisor;
+}
+
+// Given the previous block and previous stake modifier, collect all the
+// candidate blocks for the next stake modifier, compute their selection hashes
+// and sort them in the required order for Select().
+void Selection::Collect(const CBlockIndex* pindex, uint64_t stakeModifier)
+{
+    nTimeStart = RoundDown(pindex->GetBlockTime(), params.nModifierInterval) - selParams.nInterval;
+
+    // The candidates are the longest contiguous sequence of blocks up to and
+    // including the previous block (pindex) such that no block time is earlier
+    // than the selection interval.
+    vBlocks.clear();
+    while (pindex && pindex->GetBlockTime() >= nTimeStart) {
+        vBlocks.push_back(SelectionBlock{pindex, stakeModifier});
+        pindex = pindex->pprev;
+    }
+
+    // Reversal orders the candidates by increasing height, approximating
+    // the correct order.
+    std::reverse(vBlocks.begin(), vBlocks.end());
+    std::sort(vBlocks.begin(), vBlocks.end());
+}
+
+// After the candidates have been collected, select at most 64 round winners,
+// and discard the rest. The selected blocks are left in round order.
+void Selection::Select()
+{
+    nTimeStop = nTimeStart;
+
+    size_t nLimit = std::min<size_t>(64u, vBlocks.size());
+    for (size_t nRound = 0u, nRemaining = nLimit; nRemaining; --nRemaining, ++nRound) {
+        // Extend the selection interval for this round with the corresponding section.
+        nTimeStop += selParams.nIntervalSections[nRound];
+
+        // The remaining candidates start at index nRound and continue to the end
+        // of vBlocks with nondecreasing block times.
+        // If there is only one candidate, it wins by default.
+        // If there are more, the winner is the first candidate with the least
+        // selection hash among those contained in the selection interval.
+        size_t nSelected = 0u;
+        for (auto nCandidate = 1u; nRound + nCandidate < vBlocks.size(); ++nCandidate) {
+            auto& block = vBlocks[nRound + nCandidate];
+            if (block.GetTime() > nTimeStop) break;
+
+            if (block.hashSelection < vBlocks[nRound + nSelected].hashSelection)
+                nSelected = nCandidate;
+        }
+
+        // Move the winner to the round slot, keeping the remaining candidates sorted.
+        auto itBegin = vBlocks.begin() + nRound;
+        std::rotate(itBegin, itBegin + nSelected, itBegin + nSelected + 1);
+    }
+
+    // Discard losing candidates.
+    vBlocks.erase(vBlocks.begin() + nLimit, vBlocks.end());
+}
+
+// Collect the entropy bits of selected blocks into the new stake modifier.
+uint64_t Selection::ComputeModifier() const
+{
+    uint64_t nStakeModifier = 0;
+    for (auto it = vBlocks.rbegin(); it != vBlocks.rend(); ++it) {
+        nStakeModifier <<= 1;
+        nStakeModifier |= it->pindex->GetStakeEntropyBit();
+    }
+    return nStakeModifier;
+}
+
+void Selection::Log() const
+{
+    size_t nRound = 0;
+    size_t nStop = nTimeStart;
+    for (auto& block : vBlocks) {
+        nStop += selParams.nIntervalSections[nRound];
+        LogPrintf("stake modifier selection: round=%u stop=%s height=%u hash=%s\n", nRound, DateTimeStrFormat(nStop), block.pindex->nHeight, block.hashSelection.ToString());
+        ++nRound;
+    }
+}
+
+// stake modifiers
+
 // The purpose of stake modifier is to prevent a txout (coin) owner from
 // computing future proof-of-stake generated by this txout at the time
 // of transaction confirmation. To meet kernel protocol, the txout
@@ -202,371 +341,541 @@ static bool SelectBlockFromCandidates(
 // block. This is to make it difficult for an attacker to gain control of
 // additional bits in the stake modifier, even after generating a chain of
 // blocks.
-bool ComputeNextStakeModifier(const CBlockIndex* pindexCurrent, uint64_t &nStakeModifier, bool& fGeneratedStakeModifier)
+
+struct StakeModifier {
+    uint64_t nModifier = 0;
+    int64_t nTime = 0;
+    int32_t nHeight = 0;
+
+    StakeModifier() = default;
+
+    StakeModifier(const CBlockIndex& pindex)
+        : nModifier{pindex.nStakeModifier}
+        , nTime{pindex.GetBlockTime()}
+        , nHeight{pindex.nHeight}
+    {}
+
+    void Log() const;
+};
+
+void StakeModifier::Log() const
 {
-    const Consensus::Params& params = Params().GetConsensus();
-    const CBlockIndex* pindexPrev = pindexCurrent->pprev;
-    nStakeModifier = 0;
-    fGeneratedStakeModifier = false;
-    if (!pindexPrev)
-    {
-        fGeneratedStakeModifier = true;
-        return true;  // genesis block's modifier is 0
-    }
-    // First find current stake modifier and its generation block time
-    // if it's not old enough, return the same stake modifier
-    int64_t nModifierTime = 0;
-    if (!GetLastStakeModifier(pindexPrev, nStakeModifier, nModifierTime))
-        return error("ComputeNextStakeModifier: unable to get last modifier");
-    if (gArgs.GetBoolArg("-debug", false))
-        LogPrintf("ComputeNextStakeModifier: prev modifier=0x%016x time=%s epoch=%u\n", nStakeModifier, DateTimeStrFormat(nModifierTime), (unsigned int)nModifierTime);
-    if (nModifierTime / params.nModifierInterval >= pindexPrev->GetBlockTime() / params.nModifierInterval)
-    {
-        if (gArgs.GetBoolArg("-debug", false))
-            LogPrintf("ComputeNextStakeModifier: no new interval keep current modifier: pindexPrev nHeight=%d nTime=%u\n", pindexPrev->nHeight, (unsigned int)pindexPrev->GetBlockTime());
-        return true;
-    }
-    if (nModifierTime / params.nModifierInterval >= pindexCurrent->GetBlockTime() / params.nModifierInterval)
-    {
-        // v0.4+ requires current block timestamp also be in a different modifier interval
-        if (IsProtocolV04(pindexCurrent->nTime))
-        {
-            if (gArgs.GetBoolArg("-debug", false))
-                LogPrintf("ComputeNextStakeModifier: (v0.4+) no new interval keep current modifier: pindexCurrent nHeight=%d nTime=%u\n", pindexCurrent->nHeight, (unsigned int)pindexCurrent->GetBlockTime());
-            return true;
-        }
-        else
-        {
-            if (gArgs.GetBoolArg("-debug", false))
-                LogPrintf("ComputeNextStakeModifier: v0.3 modifier at block %s not meeting v0.4+ protocol: pindexCurrent nHeight=%d nTime=%u\n", pindexCurrent->GetBlockHash().ToString(), pindexCurrent->nHeight, (unsigned int)pindexCurrent->GetBlockTime());
-        }
-    }
+    LogPrintf("stake modifier=%016x at height=%d time=%s epoch=%d\n", nModifier, nHeight, DateTimeStrFormat(nTime), nTime);
+}
 
-    // Sort candidate blocks by timestamp
-    vector<pair<int64_t, uint256> > vSortedByTimestamp;
-    vSortedByTimestamp.reserve(64 * params.nModifierInterval / params.nStakeTargetSpacing);
-    int64_t nSelectionInterval = GetStakeModifierSelectionInterval();
-    int64_t nSelectionIntervalStart = (pindexPrev->GetBlockTime() / params.nModifierInterval) * params.nModifierInterval - nSelectionInterval;
-    const CBlockIndex* pindex = pindexPrev;
-    while (pindex && pindex->GetBlockTime() >= nSelectionIntervalStart)
-    {
-        vSortedByTimestamp.push_back(make_pair(pindex->GetBlockTime(), pindex->GetBlockHash()));
+const CBlockIndex* FindLastStakeModifierBlock(const CBlockIndex* pindex)
+{
+    while (pindex && !pindex->GeneratedStakeModifier())
         pindex = pindex->pprev;
+    return pindex;
+}
+
+// validation
+
+// Kernel hash is computed based on these values, rationale for each is given
+// below.
+// Block and transaction hashes should not be used here, as they can be
+// generated in vast quantities, which would degrade the system into
+// proof-of-work.
+struct HashInputs {
+    Protocol protocol = Protocol::Invalid;
+    unsigned int nBits;
+
+    // The stake modifier.
+    // (v0.2)   nBits is used, which depends on all past block timestamps.
+    // (v0.3)   Static stake modifier, around 9 days after the staked coin.
+    // (v0.5)   Dynamic stake modifier, around 21 days before the kernel.
+    uint64_t nStakeModifier;
+
+    // Block timestamp of the staked coin. Prevents nodes from guessing a good
+    // timestamp to generate transaction for future advantage.
+    unsigned int nTimeBlockFrom;
+
+    // Offset of staked coin transaction within block, its timestamp and output
+    // number. All of these reduce the chance of nodes generating coinstake at
+    // the same time.
+    unsigned int nTxPrevOffset;
+    unsigned int nTimeTxPrev;
+    unsigned int nPrevOutput;
+
+    // Kernel timestamp.
+    unsigned int nTimeTx;
+
+    //
+    uint256 ComputeHash() const;
+    void Log() const;
+};
+
+uint256 HashInputs::ComputeHash() const
+{
+    CDataStream ss{SER_GETHASH, 0};
+
+    if (protocol == Protocol::V02)
+        ss << nBits; // 4 bytes
+    else
+        ss << nStakeModifier; // 8 bytes
+
+    ss << nTimeBlockFrom << nTxPrevOffset << nTimeTxPrev << nPrevOutput << nTimeTx;
+
+    return Hash(ss.begin(), ss.end());
+}
+
+void HashInputs::Log() const
+{
+    LogPrintf("modifier=%#018x nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u",
+            nStakeModifier, nTimeBlockFrom, nTxPrevOffset, nTimeTxPrev, nPrevOutput, nTimeTx);
+}
+
+// This structure contains everything needed to validate coinstake transactions.
+struct CoinStake : public HashInputs {
+    int64_t nValueIn;
+    uint256 hashBlockFrom;
+    const CBlockIndex* pindexPrev;
+
+    void Log() const;
+
+    bool Check(const Params&, uint256& hashProofOfStake) const;
+
+    bool Load(const CTransactionRef& tx);
+
+    void DetectProtocol(Network network);
+};
+
+void CoinStake::Log() const
+{
+    LogPrintf("protocol=%s ", ProtocolName(protocol));
+    HashInputs::Log();
+    LogPrintf(" nValueIn=%d", nValueIn);
+}
+
+// Check that the coinstake transaction satisfies the kernel protocol.
+bool CoinStake::Check(const Params& params, uint256& hashProofOfStake) const
+{
+    static char const* function = "Kernel::CoinStake::Check";
+
+    // Sanity checks.
+    if (nTimeTx < nTimeTxPrev)
+        return error("%s(): transaction time violation.", function);
+    if (nTimeBlockFrom + params.nStakeMinAge > nTimeTx)
+        return error("%s(): minimal stake age violation.", function);
+
+    // Compute the kernel hash.
+    hashProofOfStake = ComputeHash();
+
+    // The target is proportional to stake age, which is limited to 90 days.
+    auto nTimeWeight = std::min<int64_t>(nTimeTx - nTimeTxPrev, params.nStakeMaxAge);
+    if (protocol >= Protocol::V03) {
+        // Starting with v0.3, coins start accumulating (positive) coin age
+        // with a 30-day delay. This increases the number of active coins
+        // participating in the hash and helps secure the network when
+        // proof-of-stake difficulty is low.
+        nTimeWeight -= params.nStakeMinAge;
     }
-    int nHeightFirstCandidate = pindex ? (pindex->nHeight + 1) : 0;
 
-    // Shuffle before sort
-    for(int i = vSortedByTimestamp.size() - 1; i > 1; --i)
-    std::swap(vSortedByTimestamp[i], vSortedByTimestamp[GetRand(i)]);
+    // The target is proportional to stake value.
+    auto bnCoinDayWeight = CBigNum(nValueIn) * nTimeWeight / COIN / (24 * 60 * 60);
 
-    sort(vSortedByTimestamp.begin(), vSortedByTimestamp.end(), [] (const pair<int64_t, uint256> &a, const pair<int64_t, uint256> &b)
-    {
-        if (a.first != b.first)
-            return a.first < b.first;
-        // Timestamp equals - compare block hashes
-        const uint32_t *pa = a.second.GetDataPtr();
-        const uint32_t *pb = b.second.GetDataPtr();
-        int cnt = 256 / 32;
-        do {
-            --cnt;
-            if (pa[cnt] != pb[cnt])
-                return pa[cnt] < pb[cnt];
-        } while(cnt);
-            return false; // Elements are equal
-    });
+    // The target depends on the current difficulty, encoded in nBits.
+    CBigNum bnTargetPerCoinDay;
+    bnTargetPerCoinDay.SetCompact(nBits);
 
-    // Select 64 blocks from candidate blocks to generate stake modifier
-    uint64_t nStakeModifierNew = 0;
-    int64_t nSelectionIntervalStop = nSelectionIntervalStart;
-    map<uint256, const CBlockIndex*> mapSelectedBlocks;
-    for (int nRound=0; nRound<min(64, (int)vSortedByTimestamp.size()); nRound++)
-    {
-        // add an interval section to the current selection round
-        nSelectionIntervalStop += GetStakeModifierSelectionIntervalSection(nRound);
-        // select a block from the candidates of current round
-        if (!SelectBlockFromCandidates(vSortedByTimestamp, mapSelectedBlocks, nSelectionIntervalStop, nStakeModifier, &pindex))
-            return error("ComputeNextStakeModifier: unable to select block at round %d", nRound);
-        // write the entropy bit of the selected block
-        nStakeModifierNew |= (((uint64_t)pindex->GetStakeEntropyBit()) << nRound);
-        // add the selected block from candidates to selected list
-        mapSelectedBlocks.insert(make_pair(pindex->GetBlockHash(), pindex));
-        if (gArgs.GetBoolArg("-debug", false) && gArgs.GetBoolArg("-printstakemodifier", false))
-            LogPrintf("ComputeNextStakeModifier: selected round %d stop=%s height=%d bit=%d\n",
-                nRound, DateTimeStrFormat(nSelectionIntervalStop), pindex->nHeight, pindex->GetStakeEntropyBit());
-    }
+    // The kernel hash must meet target.
+    if (CBigNum(hashProofOfStake) > bnCoinDayWeight * bnTargetPerCoinDay)
+        return error("%s(): proof-of-stake hash does not meet target.", function);
 
-    // Print selection map for visualization of the selected blocks
-    if (gArgs.GetBoolArg("-debug", false) && gArgs.GetBoolArg("-printstakemodifier", false))
-    {
-        string strSelectionMap = "";
-        // '-' indicates proof-of-work blocks not selected
-        strSelectionMap.insert(0, pindexPrev->nHeight - nHeightFirstCandidate + 1, '-');
-        pindex = pindexPrev;
-        while (pindex && pindex->nHeight >= nHeightFirstCandidate)
-        {
-            // '=' indicates proof-of-stake blocks not selected
-            if (pindex->IsProofOfStake())
-                strSelectionMap.replace(pindex->nHeight - nHeightFirstCandidate, 1, "=");
-            pindex = pindex->pprev;
-        }
-        for (const auto& item : mapSelectedBlocks)
-        {
-            // 'S' indicates selected proof-of-stake blocks
-            // 'W' indicates selected proof-of-work blocks
-            strSelectionMap.replace(item.second->nHeight - nHeightFirstCandidate, 1, item.second->IsProofOfStake()? "S" : "W");
-        }
-        LogPrintf("ComputeNextStakeModifier: selection height [%d, %d] map %s\n", nHeightFirstCandidate, pindexPrev->nHeight, strSelectionMap);
-    }
-    if (gArgs.GetBoolArg("-debug", false))
-        LogPrintf("ComputeNextStakeModifier: new modifier=0x%016x time=%s\n", nStakeModifierNew, DateTimeStrFormat(pindexPrev->GetBlockTime()));
-
-    nStakeModifier = nStakeModifierNew;
-    fGeneratedStakeModifier = true;
     return true;
+}
+
+bool LoadTx(const uint256& hashTx,
+    CTransactionRef& tx,
+    CBlockHeader& header,
+    unsigned int& nTxOffset)
+{
+    static char const* function = "Kernel::LoadTx";
+
+    if (!fTxIndex)
+        return error("%s(): transaction index not available", function);
+
+    CDiskTxPos posTx;
+    if (!pblocktree->ReadTxIndex(hashTx, posTx))
+        return error("%s(%s): transaction index not found", function, hashTx.ToString());
+
+    CAutoFile file(OpenBlockFile(posTx, true), SER_DISK, CLIENT_VERSION);
+    try {
+        file >> header;
+        fseek(file.Get(), posTx.nTxOffset, SEEK_CUR);
+        file >> tx;
+    } catch (...) {
+        return error("%s(%s) : deserialize or I/O error", function, hashTx.ToString());
+    }
+
+    if (tx->GetHash() != hashTx)
+        return error("%s(%s) : txid mismatch", function, hashTx.ToString());
+
+    nTxOffset = posTx.nTxOffset + CBlockHeader::NORMAL_SERIALIZE_SIZE;
+
+    return true;
+}
+
+// Load hash inputs and other data relevant for validation from the given
+// coinstake transaction and the block/transaction containing the staked coin.
+bool CoinStake::Load(const CTransactionRef& tx)
+{
+    static char const* function = "Kernel::Coinstake::Load";
+
+    auto txid = tx->GetHash().ToString();
+
+    if (!tx->IsCoinStake())
+        return error("%s(%s): not a coinstake transaction.", function, txid);
+
+    const CTxIn& kernel = tx->vin[0];
+
+    nTimeTx = tx->nTime;
+    nPrevOutput = kernel.prevout.n;
+
+    CBlockHeader blockFrom;
+    CTransactionRef txPrev;
+    if (!LoadTx(kernel.prevout.hash, txPrev, blockFrom, nTxPrevOffset))
+        return error("%s(%s): could not load staked coin.", function, txid);
+
+    hashBlockFrom = blockFrom.GetHash();
+    nTimeBlockFrom = blockFrom.GetBlockTime();
+    nTimeTxPrev = txPrev->nTime;
+    nValueIn = txPrev->vout[nPrevOutput].nValue;
+
+    return true;
+}
+
+void CoinStake::DetectProtocol(Network network)
+{
+    if (nTimeTx >= GetSwitchTime(network, Protocol::V05))
+        protocol = Protocol::V05;
+    else if (nTimeTx >= GetSwitchTime(network, Protocol::V03))
+        protocol = Protocol::V03;
+    else
+        protocol = Protocol::V02;
+}
+
+// state
+
+class State : public DebugFlags
+{
+public:
+    const Params& params;
+    const SelectionParams selParams;
+    const Network network;
+
+    State(const CChainParams& chainParams)
+        : DebugFlags{}
+        , params{chainParams.GetConsensus()}
+        , selParams{params}
+        , network{DetectNetwork(chainParams)}
+    {
+    }
+
+    bool CheckCoinStake(CoinStake&, uint256& hashProofOfStake, bool* pfDoS = nullptr) const;
+
+    bool ComputeNextStakeModifier(const CBlockIndex*, uint64_t& nStakeModifier, bool& fGenerated) const;
+
+private:
+    bool GetStakeModifierV03(const CoinStake&, StakeModifier& out) const;
+    bool GetStakeModifierV05(const CoinStake&, StakeModifier& out) const;
+};
+
+// This is the common part of CheckProofOfStake and CheckStakeKernelHash.
+// All CoinStake members except protocol and nStakeModifier are assumed to be
+// initialized.
+bool State::CheckCoinStake(CoinStake& coinStake, uint256& hashProofOfStake, bool* pfDoS) const
+{
+    static char const* function = "Kernel::State::CheckCoinStake";
+
+    coinStake.DetectProtocol(network);
+
+    // Choose the stake modifier based on protocol version.
+    if (coinStake.protocol >= Protocol::V03) {
+        StakeModifier stakeMod;
+
+        if (coinStake.protocol >= Protocol::V05) {
+            if (!GetStakeModifierV05(coinStake, stakeMod)) return false;
+        } else {
+            if (!GetStakeModifierV03(coinStake, stakeMod)) return false;
+        }
+
+        if (fDebug) stakeMod.Log();
+        coinStake.nStakeModifier = stakeMod.nModifier;
+    } else {
+        coinStake.nStakeModifier = coinStake.nBits;
+    }
+
+    bool okay = coinStake.Check(params, hashProofOfStake);
+    if (pfDoS) *pfDoS = !okay;
+
+    if (fDebug || !okay) {
+        LogPrintf("%s(): ", function);
+        coinStake.Log();
+        LogPrintf(" hashProof=%s\n", hashProofOfStake.ToString());
+    }
+
+    if (!okay)
+        return error("%s(): kernel check failed.", function);
+
+    return true;
+}
+
+/*
+bool State::CheckProofOfStake(CValidationState& state, const CTransactionRef& tx, unsigned int nBits, uint256& hashProofOfStake) const
+{
+    static char const* function = "Kernel::State::CheckProofOfStake";
+
+    CoinStake coinStake;
+    coinStake.nBits = nBits;
+
+    if (!coinStake.Load(tx))
+        return error("%s(): could not load coin stake tx.", function);
+
+    bool fDoS = false;
+    if (!CheckCoinStake(coinStake, hashProofOfStake, &fDoS))
+        return fDoS && state.DoS(1);
+
+    return true;
+}
+*/
+
+// V0.3: Stake modifier used to hash for a stake kernel is chosen as the stake
+// modifier about a selection interval later than the coin generating the kernel
+bool State::GetStakeModifierV03(const CoinStake& coinStake, StakeModifier& out) const
+{
+    auto it = mapBlockIndex.find(coinStake.hashBlockFrom);
+    if (it == mapBlockIndex.end())
+        return error("GetKernelStakeModifier() : block not indexed");
+    const CBlockIndex* pindexFrom = it->second;
+
+    auto nMinTime = pindexFrom->GetBlockTime() + selParams.nInterval;
+    auto nMinHeight = pindexFrom->nHeight;
+    auto nMaxHeight = coinStake.pindexPrev->nHeight;
+
+    const CBlockIndex* pindexBest = nullptr;
+
+    // Iterate backwards from previous block while off active chain.
+    for (auto it = coinStake.pindexPrev;
+            it->nHeight >= nMinHeight && !chainActive.Contains(it);
+            it = it->pprev)
+    {
+        if (it->GeneratedStakeModifier() && it->GetBlockTime() >= nMinTime) pindexBest = it;
+        nMaxHeight = it->nHeight - 1;
+    }
+
+    // Iterate forwards while on active chain.
+    for (auto it = pindexFrom;
+            it && it->nHeight <= nMaxHeight;
+            it = chainActive.Next(it))
+    {
+        if (it->GeneratedStakeModifier() && it->GetBlockTime() >= nMinTime)
+        {
+            pindexBest = it;
+            break;
+        }
+    }
+
+    if (pindexBest)
+    {
+        out.nModifier = pindexBest->nStakeModifier;
+        out.nHeight = pindexBest->nHeight;
+        out.nTime = pindexBest->GetBlockTime();
+    }
+
+    return !!pindexBest;
 }
 
 // V0.5: Stake modifier used to hash for a stake kernel is chosen as the stake
 // modifier that is (nStakeMinAge minus a selection interval) earlier than the
-// stake, thus at least a selection interval later than the coin generating the // kernel, as the generating coin is from at least nStakeMinAge ago.
-static bool GetKernelStakeModifierV05(CBlockIndex* pindexPrev, unsigned int nTimeTx, uint64_t& nStakeModifier, int& nStakeModifierHeight, int64_t& nStakeModifierTime, bool fPrintProofOfStake)
+// stake, thus at least a selection interval later than the coin generating the
+// kernel, as the generating coin is from at least nStakeMinAge ago.
+bool State::GetStakeModifierV05(const CoinStake& coinStake, StakeModifier& out) const
 {
-    const Consensus::Params& params = Params().GetConsensus();
-    const CBlockIndex* pindex = pindexPrev;
-    nStakeModifierHeight = pindex->nHeight;
-    nStakeModifierTime = pindex->GetBlockTime();
-    int64_t nStakeModifierSelectionInterval = GetStakeModifierSelectionInterval();
+    const CBlockIndex* pindex = coinStake.pindexPrev;
+    out.nHeight = pindex->nHeight;
+    out.nTime = pindex->GetBlockTime();
 
-    if (nStakeModifierTime + params.nStakeMinAge - nStakeModifierSelectionInterval <= (int64_t) nTimeTx)
-    {
-        // Best block is still more than
-        // (nStakeMinAge minus a selection interval) older than kernel timestamp
-        if (fPrintProofOfStake)
-            return error("GetKernelStakeModifier() : best block %s at height %d too old for stake",
-                pindex->GetBlockHash().ToString(), pindex->nHeight);
-        else
-            return false;
-    }
-    // loop to find the stake modifier earlier by 
-    // (nStakeMinAge minus a selection interval)
-    while (nStakeModifierTime + params.nStakeMinAge - nStakeModifierSelectionInterval >(int64_t) nTimeTx)
-    {
+    if (out.nTime + params.nStakeMinAge - selParams.nInterval <= coinStake.nTimeTx)
+        return error("GetKernelStakeModifier() : best block %s at height %d too old for stake",
+            pindex->GetBlockHash().ToString(), pindex->nHeight);
+
+    while (out.nTime + params.nStakeMinAge - selParams.nInterval > coinStake.nTimeTx) {
         if (!pindex->pprev)
-        {   // reached genesis block; should not happen
             return error("GetKernelStakeModifier() : reached genesis block");
-        }
         pindex = pindex->pprev;
-        if (pindex->GeneratedStakeModifier())
-        {
-            nStakeModifierHeight = pindex->nHeight;
-            nStakeModifierTime = pindex->GetBlockTime();
+        if (pindex->GeneratedStakeModifier()) {
+            out.nHeight = pindex->nHeight;
+            out.nTime = pindex->GetBlockTime();
         }
     }
-    nStakeModifier = pindex->nStakeModifier;
+
+    out.nModifier = pindex->nStakeModifier;
     return true;
 }
 
-// V0.3: Stake modifier used to hash for a stake kernel is chosen as the stake
-// modifier about a selection interval later than the coin generating the kernel
-static bool GetKernelStakeModifierV03(CBlockIndex* pindexPrev, uint256 hashBlockFrom, uint64_t& nStakeModifier, int& nStakeModifierHeight, int64_t& nStakeModifierTime, bool fPrintProofOfStake)
+bool State::ComputeNextStakeModifier(const CBlockIndex* pindexCurrent,
+    uint64_t& nStakeModifier,
+    bool& fGenerated) const
 {
-    const Consensus::Params& params = Params().GetConsensus();
+    static char const* function = "ComputeNextStakeModifier";
+
+    const CBlockIndex* pindexPrev = pindexCurrent->pprev;
+
     nStakeModifier = 0;
-    if (!mapBlockIndex.count(hashBlockFrom))
-        return error("GetKernelStakeModifier() : block not indexed");
-    const CBlockIndex* pindexFrom = mapBlockIndex[hashBlockFrom];
-    nStakeModifierHeight = pindexFrom->nHeight;
-    nStakeModifierTime = pindexFrom->GetBlockTime();
-    int64_t nStakeModifierSelectionInterval = GetStakeModifierSelectionInterval();
-
-
-    // we need to iterate index forward but we cannot depend on chainActive.Next()
-    // because there is no guarantee that we are checking blocks in active chain.
-    // So, we construct a temporary chain that we will iterate over.
-    // pindexFrom - this block contains coins that are used to generate PoS
-    // pindexPrev - this is a block that is previous to PoS block that we are checking, you can think of it as tip of our chain
-    std::vector<CBlockIndex*> tmpChain;
-    int32_t nDepth = pindexPrev->nHeight - (pindexFrom->nHeight-1); // -1 is used to also include pindexFrom
-    tmpChain.reserve(nDepth);
-    CBlockIndex* it = pindexPrev;
-    for (int i=1; i<=nDepth && !chainActive.Contains(it); i++) {
-        tmpChain.push_back(it);
-        it = it->pprev;
+    fGenerated = false;
+    if (!pindexPrev) {
+        fGenerated = true;
+        return true; // genesis block's modifier is 0
     }
-    std::reverse(tmpChain.begin(), tmpChain.end());
-    size_t n = 0;
 
-    const CBlockIndex* pindex = pindexFrom;
-    // loop to find the stake modifier later by a selection interval
-    while (nStakeModifierTime < pindexFrom->GetBlockTime() + nStakeModifierSelectionInterval)
-    {
-        const CBlockIndex* old_pindex = pindex;
-        pindex = (!tmpChain.empty() && pindex->nHeight >= tmpChain[0]->nHeight - 1)? tmpChain[n++] : chainActive.Next(pindex);
-        if (n > tmpChain.size() || pindex == NULL) // check if tmpChain[n+1] exists
-        {   // reached best block; may happen if node is behind on block chain
-            if (fPrintProofOfStake || (old_pindex->GetBlockTime() + params.nStakeMinAge - nStakeModifierSelectionInterval > GetAdjustedTime()))
-                return error("GetKernelStakeModifier() : reached best block %s at height %d from block %s",
-                    old_pindex->GetBlockHash().ToString(), old_pindex->nHeight, hashBlockFrom.ToString());
-            else
-                return false;
-        }
-        if (pindex->GeneratedStakeModifier())
-        {
-            nStakeModifierHeight = pindex->nHeight;
-            nStakeModifierTime = pindex->GetBlockTime();
+    // First find current stake modifier and its generation block time
+    // if it's not old enough, return the same stake modifier
+    auto pindexLastMod = Kernel::FindLastStakeModifierBlock(pindexPrev);
+    if (!pindexLastMod)
+        return error("%s(): cannot find last stake modifier", function);
+
+    Kernel::StakeModifier lastMod{*pindexLastMod};
+    nStakeModifier = lastMod.nModifier;
+
+    if (fDebug)
+        LogPrintf("%s(): previous modifier=%#016x time=%s epoch=%d\n", function, nStakeModifier, DateTimeStrFormat(lastMod.nTime), lastMod.nTime);
+
+    auto nModIdx = lastMod.nTime / params.nModifierInterval;
+
+    if (nModIdx >= pindexPrev->GetBlockTime() / params.nModifierInterval) {
+        if (fDebug)
+            LogPrintf("%s(): no new interval keep current modifier: pindexPrev nHeight=%d nTime=%u\n", function, pindexPrev->nHeight, (unsigned int)pindexPrev->GetBlockTime());
+        return true;
+    }
+
+    if (nModIdx >= pindexCurrent->GetBlockTime() / params.nModifierInterval) {
+        // v0.4+ requires current block timestamp also be in a different modifier interval
+        if (pindexCurrent->nTime >= Kernel::GetSwitchTime(network, Kernel::Protocol::V04)) {
+            if (fDebug)
+                LogPrintf("%s(v0.4+): no new interval keep current modifier: pindexCurrent nHeight=%d nTime=%u\n", function, pindexCurrent->nHeight, (unsigned int)pindexCurrent->GetBlockTime());
+            return true;
+        } else {
+            if (fDebug)
+                LogPrintf("%s(): v0.3 modifier at block %s not meeting v0.4+ protocol: pindexCurrent nHeight=%d nTime=%u\n", function, pindexCurrent->GetBlockHash().ToString(), pindexCurrent->nHeight, (unsigned int)pindexCurrent->GetBlockTime());
         }
     }
-    nStakeModifier = pindex->nStakeModifier;
+
+    // Compute the next stake modifier from selected preceding blocks.
+    Selection sel{params, selParams};
+    sel.Collect(pindexPrev, lastMod.nModifier);
+    sel.Select();
+
+    nStakeModifier = sel.ComputeModifier();
+    fGenerated = true;
+
+    if (fDebug) {
+        if (fPrintStakeModifier) sel.Log();
+        LogPrintf("%s(): new stake modifier=%#016x\n", function, nStakeModifier);
+    }
+
     return true;
 }
 
-// Get the stake modifier specified by the protocol to hash for a stake kernel
-static bool GetKernelStakeModifier(CBlockIndex* pindexPrev, uint256 hashBlockFrom, unsigned int nTimeTx, uint64_t& nStakeModifier, int& nStakeModifierHeight, int64_t& nStakeModifierTime, bool fPrintProofOfStake)
+} // namespace Kernel
+
+// Whether the given coinstake is subject to new v0.3 protocol
+bool IsProtocolV03(unsigned int nTimeCoinStake)
 {
-    if (IsProtocolV05(nTimeTx))
-        return GetKernelStakeModifierV05(pindexPrev, nTimeTx, nStakeModifier, nStakeModifierHeight, nStakeModifierTime, fPrintProofOfStake);
-    else
-        return GetKernelStakeModifierV03(pindexPrev, hashBlockFrom, nStakeModifier, nStakeModifierHeight, nStakeModifierTime, fPrintProofOfStake);
+    auto network = Kernel::DetectNetwork(Params());
+    return nTimeCoinStake >= Kernel::GetSwitchTime(network, Kernel::Protocol::V03);
 }
 
-// peercoin kernel protocol
-// coinstake must meet hash target according to the protocol:
-// kernel (input 0) must meet the formula
-//     hash(nStakeModifier + txPrev.block.nTime + txPrev.offset + txPrev.nTime + txPrev.vout.n + nTime) < bnTarget * nCoinDayWeight
-// this ensures that the chance of getting a coinstake is proportional to the
-// amount of coin age one owns.
-// The reason this hash is chosen is the following:
-//   nStakeModifier: 
-//       (v0.5) uses dynamic stake modifier around 21 days before the kernel,
-//              versus static stake modifier about 9 days after the staked
-//              coin (txPrev) used in v0.3
-//       (v0.3) scrambles computation to make it very difficult to precompute
-//              future proof-of-stake at the time of the coin's confirmation
-//       (v0.2) nBits (deprecated): encodes all past block timestamps
-//   txPrev.block.nTime: prevent nodes from guessing a good timestamp to
-//                       generate transaction for future advantage
-//   txPrev.offset: offset of txPrev inside block, to reduce the chance of 
-//                  nodes generating coinstake at the same time
-//   txPrev.nTime: reduce the chance of nodes generating coinstake at the same
-//                 time
-//   txPrev.vout.n: output number of txPrev, to reduce the chance of nodes
-//                  generating coinstake at the same time
-//   block/tx hash should not be used here as they can be generated in vast
-//   quantities so as to generate blocks faster, degrading the system back into
-//   a proof-of-work situation.
-//
-bool CheckStakeKernelHash(unsigned int nBits, CBlockIndex* pindexPrev, const CBlockHeader& blockFrom, unsigned int nTxPrevOffset, const CTransactionRef& txPrev, const COutPoint& prevout, unsigned int nTimeTx, uint256& hashProofOfStake, bool fPrintProofOfStake)
+// Whether the given block is subject to new v0.4 protocol
+bool IsProtocolV04(unsigned int nTimeBlock)
 {
-    const Consensus::Params& params = Params().GetConsensus();
-    if (nTimeTx < txPrev->nTime)  // Transaction timestamp violation
-        return error("CheckStakeKernelHash() : nTime violation");
+    auto network = Kernel::DetectNetwork(Params());
+    return nTimeBlock >= Kernel::GetSwitchTime(network, Kernel::Protocol::V04);
+}
 
-    unsigned int nTimeBlockFrom = blockFrom.GetBlockTime();
-    if (nTimeBlockFrom + params.nStakeMinAge > nTimeTx) // Min age requirement
-        return error("CheckStakeKernelHash() : min age violation");
+// Whether the given transaction is subject to new v0.5 protocol
+bool IsProtocolV05(unsigned int nTimeTx)
+{
+    auto network = Kernel::DetectNetwork(Params());
+    return nTimeTx >= Kernel::GetSwitchTime(network, Kernel::Protocol::V05);
+}
 
-    CBigNum bnTargetPerCoinDay;
-    bnTargetPerCoinDay.SetCompact(nBits);
-    int64_t nValueIn = txPrev->vout[prevout.n].nValue;
-    // v0.3 protocol kernel hash weight starts from 0 at the 30-day min age
-    // this change increases active coins participating the hash and helps
-    // to secure the network when proof-of-stake difficulty is low
-    int64_t nTimeWeight = min((int64_t)nTimeTx - txPrev->nTime, params.nStakeMaxAge) - (IsProtocolV03(nTimeTx)? params.nStakeMinAge : 0);
-    CBigNum bnCoinDayWeight = CBigNum(nValueIn) * nTimeWeight / COIN / (24 * 60 * 60);
-    // Calculate hash
-    CDataStream ss(SER_GETHASH, 0);
-    uint64_t nStakeModifier = 0;
-    int nStakeModifierHeight = 0;
-    int64_t nStakeModifierTime = 0;
-    if (IsProtocolV03(nTimeTx))  // v0.3 protocol
-    {
-        if (!GetKernelStakeModifier(pindexPrev, blockFrom.GetHash(), nTimeTx, nStakeModifier, nStakeModifierHeight, nStakeModifierTime, fPrintProofOfStake))
-            return false;
-        ss << nStakeModifier;
-    }
-    else // v0.2 protocol
-    {
-        ss << nBits;
-    }
-
-    ss << nTimeBlockFrom << nTxPrevOffset << txPrev->nTime << prevout.n << nTimeTx;
-    hashProofOfStake = Hash(ss.begin(), ss.end());
-    if (fPrintProofOfStake)
-    {
-        if (IsProtocolV03(nTimeTx))
-            LogPrintf("CheckStakeKernelHash() : using modifier 0x%016x at height=%d timestamp=%s for block from height=%d timestamp=%s\n",
-                nStakeModifier, nStakeModifierHeight,
-                DateTimeStrFormat(nStakeModifierTime),
-                mapBlockIndex[blockFrom.GetHash()]->nHeight,
-                DateTimeStrFormat(blockFrom.GetBlockTime()));
-        LogPrintf("CheckStakeKernelHash() : check protocol=%s modifier=0x%016x nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u hashProof=%s\n",
-            IsProtocolV05(nTimeTx)? "0.5" : (IsProtocolV03(nTimeTx)? "0.3" : "0.2"),
-            IsProtocolV03(nTimeTx)? nStakeModifier : (uint64_t) nBits,
-            nTimeBlockFrom, nTxPrevOffset, txPrev->nTime, prevout.n, nTimeTx,
-            hashProofOfStake.ToString());
-    }
-
-    // Now check if proof-of-stake hash meets target protocol
-    if (CBigNum(hashProofOfStake) > bnCoinDayWeight * bnTargetPerCoinDay)
+// Whether a given block is subject to new v0.6 protocol
+// Test against previous block index! (always available)
+bool IsProtocolV06(const CBlockIndex* pindexPrev)
+{
+    auto network = Kernel::DetectNetwork(Params());
+    if (pindexPrev->nTime < Kernel::GetSwitchTime(network, Kernel::Protocol::V06))
         return false;
-    if (gArgs.GetBoolArg("-debug", false) && !fPrintProofOfStake)
-    {
-        if (IsProtocolV03(nTimeTx))
-            LogPrintf("CheckStakeKernelHash() : using modifier 0x%016x at height=%d timestamp=%s for block from height=%d timestamp=%s\n",
-                nStakeModifier, nStakeModifierHeight, 
-                DateTimeStrFormat(nStakeModifierTime),
-                mapBlockIndex[blockFrom.GetHash()]->nHeight,
-                DateTimeStrFormat(blockFrom.GetBlockTime()));
-        LogPrintf("CheckStakeKernelHash() : pass protocol=%s modifier=0x%016x nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u hashProof=%s\n",
-            IsProtocolV03(nTimeTx)? "0.3" : "0.2",
-            IsProtocolV03(nTimeTx)? nStakeModifier : (uint64_t) nBits,
-            nTimeBlockFrom, nTxPrevOffset, txPrev->nTime, prevout.n, nTimeTx,
-            hashProofOfStake.ToString());
+
+    // if 900 of the last 1,000 blocks are version 2 or greater (90/100 if testnet):
+    // Soft-forking PoS can be dangerous if the super majority is too low
+    // The stake majority will decrease after the fork
+    // since only coindays of updated nodes will get destroyed.
+    switch (network) {
+    case Kernel::Network::Main:
+        return IsSuperMajority(2, pindexPrev, 900, 1000);
+
+    case Kernel::Network::Test:
+        return IsSuperMajority(2, pindexPrev, 90, 100);
+
+    default:
+        return false;
     }
-    return true;
+}
+
+// Whether a given transaction is subject to new v0.7 protocol
+bool IsProtocolV07(unsigned int nTimeTx)
+{
+    auto network = Kernel::DetectNetwork(Params());
+    return nTimeTx >= GetSwitchTime(network, Kernel::Protocol::V07);
+}
+
+bool IsBTC16BIPsEnabled(uint32_t nTimeTx)
+{
+    return nTimeTx >= Kernel::nBTC16BIPsSwitchTime;
+}
+
+bool ComputeNextStakeModifier(const CBlockIndex* pindexCurrent, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier)
+{
+    Kernel::State kernel{Params()};
+    return kernel.ComputeNextStakeModifier(pindexCurrent, nStakeModifier, fGeneratedStakeModifier);
+}
+
+bool CheckStakeKernelHash(unsigned int nBits, const CBlockIndex* pindexPrev, const CBlockHeader& blockFrom, unsigned int nTxPrevOffset, const CTransactionRef& txPrev, const COutPoint& prevout, unsigned int nTimeTx, uint256& hashProofOfStake, bool fPrintProofOfStake)
+{
+    Kernel::State kernel{Params()};
+
+    Kernel::CoinStake x;
+    x.nBits = nBits;
+    x.pindexPrev = pindexPrev;
+    x.hashBlockFrom = blockFrom.GetHash();
+    x.nTimeBlockFrom = blockFrom.GetBlockTime();
+    x.nTxPrevOffset = nTxPrevOffset;
+    x.nTimeTxPrev = txPrev->nTime;
+    x.nPrevOutput = prevout.n;
+    x.nValueIn = txPrev->vout[prevout.n].nValue;
+    x.nTimeTx = nTimeTx;
+
+    return kernel.CheckCoinStake(x, hashProofOfStake);
 }
 
 // Check kernel hash target and coinstake signature
-bool CheckProofOfStake(CValidationState &state, CBlockIndex* pindexPrev, const CTransactionRef& tx, unsigned int nBits, uint256& hashProofOfStake)
+bool CheckProofOfStake(CValidationState& state, const CBlockIndex* pindexPrev, const CTransactionRef& tx, unsigned int nBits, uint256& hashProofOfStake)
 {
-    if (!tx->IsCoinStake())
-        return error("CheckProofOfStake() : called on non-coinstake %s", tx->GetHash().ToString());
+    Kernel::State kernel{Params()};
 
-    // Kernel (input 0) must match the stake hash target per coin age (nBits)
-    const CTxIn& txin = tx->vin[0];
+    Kernel::CoinStake coinStake;
+    coinStake.nBits = nBits;
+    coinStake.pindexPrev = pindexPrev;
 
-    // Transaction index is required to get to block header
-    if (!fTxIndex)
-        return error("CheckProofOfStake() : transaction index not available");
+    if (!coinStake.Load(tx))
+        return error("CheckProofOfStake(): could not load coin stake tx.");
 
-    // Get transaction index for the previous transaction
-    CDiskTxPos postx;
-    if (!pblocktree->ReadTxIndex(txin.prevout.hash, postx))
-        return error("CheckProofOfStake() : tx index not found");  // tx index not found
-
-    // Read txPrev and header of its block
-    CBlockHeader header;
-    CTransactionRef txPrev;
-    {
-        CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
-        try {
-            file >> header;
-            fseek(file.Get(), postx.nTxOffset, SEEK_CUR);
-            file >> txPrev;
-        } catch (std::exception &e) {
-            return error("%s() : deserialize or I/O error in CheckProofOfStake()", __PRETTY_FUNCTION__);
-        }
-        if (txPrev->GetHash() != txin.prevout.hash)
-            return error("%s() : txid mismatch in CheckProofOfStake()", __PRETTY_FUNCTION__);
-    }
-
-    //ppcTODO - do we need to verify it here? Wasn't it already verified in script/interpreter.cpp?
-//    // Verify signature
-//    Coin coin(txPrev, 0);
-//    if (!VerifySignature(coin, tx, 0, SCRIPT_VERIFY_P2SH, 0))
-//        return state.DoS(100, error("CheckProofOfStake() : VerifySignature failed on coinstake %s", tx.GetHash().ToString()));
-
-    if (!CheckStakeKernelHash(nBits, pindexPrev, header, postx.nTxOffset + CBlockHeader::NORMAL_SERIALIZE_SIZE, txPrev, txin.prevout, tx->nTime, hashProofOfStake, gArgs.GetBoolArg("-debug", false)))
-        return state.DoS(1, error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s", tx->GetHash().ToString(), hashProofOfStake.ToString())); // may occur during initial download or if behind on block chain sync
+    bool fDoS = false;
+    if (!kernel.CheckCoinStake(coinStake, hashProofOfStake, &fDoS))
+        return fDoS && state.DoS(1);
 
     return true;
 }
@@ -574,7 +883,8 @@ bool CheckProofOfStake(CValidationState &state, CBlockIndex* pindexPrev, const C
 // Check whether the coinstake timestamp meets protocol
 bool CheckCoinStakeTimestamp(int64_t nTimeBlock, int64_t nTimeTx)
 {
-    if (IsProtocolV03(nTimeTx))  // v0.3 protocol
+    auto network = Kernel::DetectNetwork(Params());
+    if (nTimeTx >= Kernel::GetSwitchTime(network, Kernel::Protocol::V03)) // v0.3 protocol
         return (nTimeBlock == nTimeTx);
     else // v0.2 protocol
         return ((nTimeTx <= nTimeBlock) && (nTimeBlock <= nTimeTx + MAX_FUTURE_BLOCK_TIME));
@@ -583,7 +893,7 @@ bool CheckCoinStakeTimestamp(int64_t nTimeBlock, int64_t nTimeTx)
 // Get stake modifier checksum
 unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
 {
-    assert (pindex->pprev || pindex->GetBlockHash() == Params().GetConsensus().hashGenesisBlock);
+    assert(pindex->pprev || pindex->GetBlockHash() == Params().GetConsensus().hashGenesisBlock);
     // Hash previous checksum with flags, hashProofOfStake and nStakeModifier
     CDataStream ss(SER_GETHASH, 0);
     if (pindex->pprev)
@@ -597,21 +907,14 @@ unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
 // Check stake modifier hard checkpoints
 bool CheckStakeModifierCheckpoints(int nHeight, unsigned int nStakeModifierChecksum)
 {
-    bool fTestNet = Params().NetworkIDString() == CBaseChainParams::TESTNET;
-    if (fTestNet && mapStakeModifierTestnetCheckpoints.count(nHeight))
-        return nStakeModifierChecksum == mapStakeModifierTestnetCheckpoints[nHeight];
-
-    if (!fTestNet && mapStakeModifierCheckpoints.count(nHeight))
-        return nStakeModifierChecksum == mapStakeModifierCheckpoints[nHeight];
-
-    return true;
+    auto network = Kernel::DetectNetwork(Params());
+    return Kernel::CheckStakeModifierChecksum(network, nHeight, nStakeModifierChecksum);
 }
 
 bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned int nRequired, unsigned int nToCheck)
 {
     unsigned int nFound = 0;
-    for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != NULL; pstart = pstart->pprev )
-    {
+    for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != NULL; pstart = pstart->pprev) {
         if (!pstart->IsProofOfStake())
             continue;
 
@@ -626,23 +929,36 @@ bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned int nRe
 // peercoin: entropy bit for stake modifier if chosen by modifier
 unsigned int GetStakeEntropyBit(const CBlock& block)
 {
+    Kernel::DebugFlags flags;
+    auto network = Kernel::DetectNetwork(Params());
+    bool fV04 = block.nTime >= Kernel::GetSwitchTime(network, Kernel::Protocol::V04);
+
     unsigned int nEntropyBit = 0;
-    if (IsProtocolV04(block.nTime))
-    {
-        nEntropyBit = UintToArith256(block.GetHash()).GetLow64() & 1llu;// last bit of block hash
-        if (gArgs.GetBoolArg("-printstakemodifier", false))
-            LogPrintf("GetStakeEntropyBit(v0.4+): nTime=%u hashBlock=%s entropybit=%d\n", block.nTime, block.GetHash().ToString(), nEntropyBit);
-    }
-    else
-    {
+    std::string logHash;
+
+    if (fV04) {
+        auto hashBlock = block.GetHash();
+        nEntropyBit = UintToArith256(hashBlock).GetLow64() & 1llu; // last bit of block hash
+
+        if (flags.fPrintStakeModifier) {
+            logHash = "Block=";
+            logHash += hashBlock.ToString();
+        }
+    } else {
         // old protocol for entropy bit pre v0.4
         uint160 hashSig = Hash160(block.vchBlockSig);
-        if (gArgs.GetBoolArg("-printstakemodifier", false))
-            LogPrintf("GetStakeEntropyBit(v0.3): nTime=%u hashSig=%s", block.nTime, hashSig.ToString());
-        nEntropyBit = hashSig.GetDataPtr()[4] >> 31;  // take the first bit of the hash
-        if (gArgs.GetBoolArg("-printstakemodifier", false))
-            LogPrintf(" entropybit=%d\n", nEntropyBit);
+        nEntropyBit = hashSig.GetDataPtr()[4] >> 31; // take the first bit of the hash
+
+        if (flags.fPrintStakeModifier) {
+            logHash = "Sig=";
+            logHash += hashSig.ToString();
+        }
     }
+
+    if (flags.fPrintStakeModifier)
+        LogPrintf("GetStakeEntropyBit(%s): nTime=%d, hash%s, entropyBit=%d\n",
+            fV04 ? "v0.4+" : "v0.3", block.nTime, logHash, nEntropyBit);
+
     return nEntropyBit;
 }
 

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -16,10 +16,6 @@ class CBlock;
 // ratio of group interval length between the last group and the first group
 static const int MODIFIER_INTERVAL_RATIO = 3;
 
-// Protocol switch time of v0.3 kernel protocol
-extern unsigned int nProtocolV03SwitchTime;
-extern unsigned int nProtocolV03TestSwitchTime;
-
 // Whether a given coinstake is subject to new v0.3 protocol
 bool IsProtocolV03(unsigned int nTimeCoinStake);
 // Whether a given block is subject to new v0.4 protocol
@@ -39,11 +35,11 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexCurrent, uint64_t& nStake
 
 // Check whether stake kernel meets hash target
 // Sets hashProofOfStake on success return
-bool CheckStakeKernelHash(unsigned int nBits, CBlockIndex* pindexPrev, const CBlockHeader& blockFrom, unsigned int nTxPrevOffset, const CTransactionRef& txPrev, const COutPoint& prevout, unsigned int nTimeTx, uint256& hashProofOfStake, bool fPrintProofOfStake=false);
+bool CheckStakeKernelHash(unsigned int nBits, const CBlockIndex* pindexPrev, const CBlockHeader& blockFrom, unsigned int nTxPrevOffset, const CTransactionRef& txPrev, const COutPoint& prevout, unsigned int nTimeTx, uint256& hashProofOfStake, bool fPrintProofOfStake=false);
 
 // Check kernel hash target and coinstake signature
 // Sets hashProofOfStake on success return
-bool CheckProofOfStake(CValidationState &state, CBlockIndex* pindexPrev, const CTransactionRef &tx, unsigned int nBits, uint256& hashProofOfStake);
+bool CheckProofOfStake(CValidationState &state, const CBlockIndex* pindexPrev, const CTransactionRef &tx, unsigned int nBits, uint256& hashProofOfStake);
 
 // Check whether the coinstake timestamp meets protocol
 bool CheckCoinStakeTimestamp(int64_t nTimeBlock, int64_t nTimeTx);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -53,6 +53,12 @@ public:
     friend inline bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }
     friend inline bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
 
+    inline bool ReversedLess(const base_blob& other) const {
+        auto p1 = data + WIDTH, p2 = other.data + WIDTH;
+        do { --p1; --p2; } while (*p1 == *p2 && p1 != data);
+        return *p1 < *p2;
+    }
+
     std::string GetHex() const;
     void SetHex(const char* psz);
     void SetHex(const std::string& str);


### PR DESCRIPTION
Not yet ready for merging in any case, looking for some feedback.

The original code was hard for me to read and maintain a mental model of, but mostly due to visual clutter. Some of the ways that could be improved were immediately obvious. As I pulled out chunks of code into the `Kernel` namespace, the remaining code gradually became easier to follow.

I've explored different ways of wiring the pieces back together, eventually converging to what you see here. My priority was to identify where each piece of data comes from, where it needs to get to, and how to get it there painlessly. I expect some of the choices I've made seem a bit silly, ask and I'll try to offer reasons. Also, certain parts were replaced entirely with new code, if I thought the problem could be solved in some better way.

* `Kernel::DetectNetwork()` compares against the `EXT_PUBLIC_KEY` parameter, whereas the old code called `CChainParams::NetworkIDString()` repeatedly, needlessly copying the string every time.

* `Kernel::SelectionParams` holds the stake modifier selection interval and its sections, computed only once based on `nModifierInterval`.

* `Kernel::Selection::Select()` starts with a sorted vector of blocks and in round `n` moves the selected block to index `n`, keeping the remaining candidates in order, from index `n+1` to the end. No need for a `std::map` to track which blocks have already been selected.

* Related data is grouped into structs, eg. `Kernel::HashInputs`, `Kernel::Validation`. Code is split into smaller functions, mostly methods on appropriate structs to keep the number of arguments passed around reasonable.

* `Kernel::CState` when constructed precomputes stuff that's not going to change, such as command-line flags and the selection parameters mentioned above. Of course, these are automatically in scope in its methods, among which are the "entry points" to the refactorized code, `CheckProofOfStake()` and `ComputeNextStakeModifier`.

* What's left of the old code remains on the bottom of `kernel.cpp`, maintaining the interface. Comments are mostly gone, but it any case must be rewritten after recomparing with the original code and comments to make sure they do the same exact thing.

* `IsSuperMajority()` might benefit from maintaining state across calls, say a window of previous n blocks and a count of how many of those fulfill the condition.

I had fun doing this, and certainly gained a lot of insight, but I want outside confirmation that this makes sense and seems useful before continuing.