### PR TITLE
A potential fix for the weird send entries layout.

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QFrame" name="frameCoinControl">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -54,7 +54,7 @@
        <number>6</number>
       </property>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayoutCoinControl" stretch="0,0,0,0,1">
+       <layout class="QVBoxLayout" name="verticalLayoutCoinControl" stretch="0,0,0,0">
         <property name="spacing">
          <number>0</number>
         </property>
@@ -559,19 +559,6 @@
           </item>
          </layout>
         </item>
-        <item>
-         <spacer name="verticalSpacerCoinControl">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>800</width>
-            <height>1</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
        </layout>
       </item>
      </layout>
@@ -601,7 +588,7 @@
         <x>0</x>
         <y>0</y>
         <width>830</width>
-        <height>238</height>
+        <height>297</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0">

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -10,6 +10,12 @@
     <height>156</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="focusPolicy">
    <enum>Qt::TabFocus</enum>
   </property>
@@ -1261,6 +1267,7 @@
    <class>BitcoinAmountField</class>
    <extends>QLineEdit</extends>
    <header>qt/bitcoinamountfield.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -28,6 +28,7 @@
 #include <QScrollBar>
 #include <QSettings>
 #include <QTextDocument>
+#include <Qt>
 
 static const std::array<int, 9> confTargets = { {2, 4, 6, 12, 24, 48, 144, 504, 1008} };
 int getConfTargetForIndex(int index) {
@@ -58,6 +59,8 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
     platformStyle(_platformStyle)
 {
     ui->setupUi(this);
+    ui->entries->setAlignment(Qt::AlignLeft);
+    ui->entries->setAlignment(Qt::AlignTop);
 
     if (!_platformStyle->getImagesOnButtons()) {
         ui->addButton->setIcon(QIcon());


### PR DESCRIPTION
The changes in `sendcoinsentry.ui` came from Qt Designer, I changed the vertical sizing policy to "Fixed" so the send entries wouldn't try to expand vertically.

The changes in `sendcoinsdialog.cpp` are making the `VBoxLayout` `entries` put the entries at the top of the layout, otherwise it was putting it in the center of the page. I wanted to set the alignment in Qt Designer but it wasn't available for some reason :\

![image](https://user-images.githubusercontent.com/396781/63228904-deec2900-c1ae-11e9-89a7-06b51e196944.png)
