### PR TITLE
Configure to build tests, has been successfully running 0 tests :(

### DIFF
--- a/scripts/dependencies-ubuntu.sh
+++ b/scripts/dependencies-ubuntu.sh
@@ -9,3 +9,5 @@ sudo apt-get install -y -qq qtbase5-dev qttools5-dev-tools
 sudo apt-get install -y -qq libdb++-dev
 #for debuild
 sudo apt-get install -y -qq libfakeroot fakeroot
+#for tests (hexdump)
+sudo apt-get install -y -qq bsdmainutils

--- a/scripts/install-ubuntu.sh
+++ b/scripts/install-ubuntu.sh
@@ -8,6 +8,6 @@ g++ --version
 sudo ln -sf `pwd`/db4/include /usr/local/include/bdb4.8
 sudo ln -sf `pwd`/db4/lib/*.a /usr/local/lib
 ./autogen.sh
-./configure --with-gui=qt5
+./configure --with-gui=qt5 --enable-tests
 make -j$(nproc)
 make check


### PR DESCRIPTION
I was thinking about adding some unit tests to a function in `release-0.9` but noticed that running `make check` locally is saying 0 tests are being run. It looks like the tests have to be enabled in the `./configure --enable-tests` step of compiling in order for the test suite to exist now?

From https://travis-ci.org/github/peercoin/peercoin/jobs/666455029 : 
```
============================================================================
Testsuite summary for Peercoin 0.9.0
============================================================================
# TOTAL: 0
# PASS:  0
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

This pull request gets the tests to compile but runs into errors. From https://travis-ci.org/github/belovachap/peercoin/jobs/667456464 : 
```
test/test_bitcoin.cpp: In constructor ‘TestChain100Setup::TestChain100Setup()’:
test/test_bitcoin.cpp:127:25: error: ‘COINBASE_MATURITY’ was not declared in this scope
     for (int i = 0; i < COINBASE_MATURITY; i++)
                         ^
Makefile:8649: recipe for target 'test/qt_test_test_peercoin_qt-test_bitcoin.o' failed
```

So I suppose there's more work to be done to get them running and passing.