### PR TITLE
fix qt dpi scaling attribute complaint

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -562,13 +562,12 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(bitcoin);
     Q_INIT_RESOURCE(bitcoin_locale);
 
-    BitcoinApplication app(argc, argv);
 #if QT_VERSION > 0x050100
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 #if QT_VERSION >= 0x050600
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
@@ -585,6 +584,8 @@ int main(int argc, char *argv[])
 
     Q_ASSERT(QSslConfiguration::defaultConfiguration().protocol() == QSsl::TlsV1_0OrLater);
 #endif
+
+	BitcoinApplication app(argc, argv);
 
     // Register meta types used for QMetaObject::invokeMethod
     qRegisterMetaType< bool* >();


### PR DESCRIPTION
In Ubuntu 20.04, qt binary will throw a warning upon starting up:
`Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created.`
with Qt version 5.12.8

This pull requests fixes the placement of `BitcoinApplication app(argc, argv);`.