### PR TITLE
Dynamically compute coin age

### DIFF
--- a/src/kernelrecord.h
+++ b/src/kernelrecord.h
@@ -13,20 +13,20 @@ class KernelRecord
 {
 public:
     KernelRecord():
-        hash(), nTime(0), address(""), nValue(0), idx(0), spent(false), coinAge(0), prevMinutes(0), prevDifficulty(0), prevProbability(0)
+        hash(), nTime(0), address(""), nValue(0), idx(0), spent(false), prevMinutes(0), prevDifficulty(0), prevProbability(0)
     {
     }
 
     KernelRecord(uint256 hash, int64_t nTime):
-            hash(hash), nTime(nTime), address(""), nValue(0), idx(0), spent(false), coinAge(0), prevMinutes(0), prevDifficulty(0), prevProbability(0)
+            hash(hash), nTime(nTime), address(""), nValue(0), idx(0), spent(false), prevMinutes(0), prevDifficulty(0), prevProbability(0)
     {
     }
 
     KernelRecord(uint256 hash, int64_t nTime,
                  const std::string &address,
-                 int64_t nValue, int idx, bool spent, int64_t coinAge):
+                 int64_t nValue, int idx, bool spent):
         hash(hash), nTime(nTime), address(address), nValue(nValue),
-        idx(idx), spent(spent), coinAge(coinAge), prevMinutes(0), prevDifficulty(0), prevProbability(0)
+        idx(idx), spent(spent), prevMinutes(0), prevDifficulty(0), prevProbability(0)
     {
     }
 
@@ -40,10 +40,10 @@ public:
     int64_t nValue;
     int idx;
     bool spent;
-    int64_t coinAge;
 
     std::string getTxID();
     int64_t getAge() const;
+    int64_t getCoinAge() const;
     double getProbToMintStake(double difficulty, int timeOffset = 0) const;
     double getProbToMintWithinNMinutes(double difficulty, int minutes);
 protected:

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -390,7 +390,7 @@ QVariant MintingTableModel::data(const QModelIndex &index, int role) const
         case Age:
             return qint64(rec->getAge());
         case CoinDay:
-            return qint64(rec->coinAge);
+            return qint64(rec->getCoinAge());
         case Balance:
             return qint64(rec->nValue);
         case MintProbability:
@@ -466,7 +466,7 @@ QString MintingTableModel::formatTxHash(const KernelRecord *wtx) const
 
 QString MintingTableModel::formatTxCoinDay(const KernelRecord *wtx) const
 {
-    return QString::number(wtx->coinAge);
+    return QString::number(wtx->getCoinAge());
 }
 
 QString MintingTableModel::formatTxAge(const KernelRecord *wtx) const

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3379,7 +3379,7 @@ UniValue listminting(const JSONRPCRequest& request)
                 std::string strTime = boost::lexical_cast<std::string>(kr.nTime);
                 std::string strAmount = boost::lexical_cast<std::string>(kr.nValue);
                 std::string strAge = boost::lexical_cast<std::string>(kr.getAge());
-                std::string strCoinAge = boost::lexical_cast<std::string>(kr.coinAge);
+                std::string strCoinAge = boost::lexical_cast<std::string>(kr.getCoinAge());
 
                 JSONRPCRequest request2;
                 request2.params = UniValue(UniValue::VARR);


### PR DESCRIPTION
This resolves #543 so that the CoinDay column in the minting table works as intended.