### PR TITLE
Instead of the initial pop-up unlocking the wallet, decrypt it for minting only.

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -139,7 +139,7 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
         // Show progress dialog
         connect(_walletModel, &WalletModel::showProgress, this, &WalletView::showProgress);
 
-        this->unlockWallet();
+        this->decryptForMinting(true);
     }
 }
 


### PR DESCRIPTION
I think the current mood is to remove the initial unlock pop up all together (which might just mean deleting this line). But switching this function let me decrypt the wallet for minting only on start up.