### PR TITLE
Install appimagecraft from github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
         run: |
           apt-get -qq update
           apt-get install -qqy git wget ca-certificates
-          pip3 install --upgrade git+https://www.opencode.net/azubieta/appimagecraft.git
+          pip3 install --upgrade git+https://github.com/AppImageCrafters/appimage-builder.git
 
       - name: Get short SHA
         id: slug


### PR DESCRIPTION
opencode.net appears to be very dead, and probably outdated. Get it from github instead.