### PR TITLE
Old commits should not override new dev releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,6 +297,9 @@ jobs:
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
         run: sudo apt-get update && sudo apt-get install -y mktorrent gpg bash
 
+      - uses: actions/checkout@v2
+        if: ${{ steps.detect.outputs.tag-name != 'noop' }}
+
       - uses: actions/download-artifact@v2
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
 
@@ -319,6 +322,7 @@ jobs:
       - name: Create torrent
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
         run: |
+          rm -rf ${{ steps.detect.outputs.tag-name }}/*
           mkdir -p ${{ steps.detect.outputs.tag-name }}
           mv peercoin-*-**/peercoin-*.tar.gz \
             peercoin-*-**/peercoin-*.zip \
@@ -338,8 +342,16 @@ jobs:
             -a udp://exodus.desync.com:6969/announce \
           ${{ steps.detect.outputs.tag-name }}
 
-      - uses: actions/checkout@v2
-        if: ${{ steps.detect.outputs.tag-name != 'noop' && startsWith(github.ref, 'refs/tags/v') }}
+      - name: Check latest
+        id: detect-publish-latest
+        if: ${{ steps.detect.outputs.tag-name != 'noop' && github.ref == 'refs/heads/develop' }}
+        run: |
+          PUBLISH=noop
+          git fetch origin +refs/tags/latest:refs/tags/latest
+          if ! git merge-base --is-ancestor refs/tags/latest HEAD; then
+            PUBLISH=op
+          fi
+          echo ::set-output name=publish::$PUBLISH
 
       - name: Generate Changelog
         if: ${{ steps.detect.outputs.tag-name != 'noop' && startsWith(github.ref, 'refs/tags/v') }}
@@ -348,7 +360,7 @@ jobs:
           git tag -l --format='%(contents)' ${GITHUB_REF/refs\/tags\//} > ${{ github.workspace }}-CHANGELOG.txt
 
       - uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
-        if: ${{ steps.detect.outputs.tag-name != 'noop' && github.ref == 'refs/heads/develop' }}
+        if: ${{ steps.detect.outputs.tag-name != 'noop' && steps.detect-publish-latest.outputs.publish == 'op' && github.ref == 'refs/heads/develop' }}
         with:
           repo_token: ${{ github.token }}
           automatic_release_tag: ${{ steps.detect.outputs.tag-name }}


### PR DESCRIPTION
Right now, whichever pipeline finishes last, will get to publish the latest development release.
This behavior is technically correct, but might not be very intuitive.
This commit will check if the commit we're building towards is included in the `latest` tag (published by the last pipeline which got to update the latest development release) and then disable the relevant release action.