### PR TITLE
various build fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,13 +57,9 @@ jobs:
 
       - name: Fetch OSX SDK
         if: ${{ matrix.os == 'osx' }}
-        run: |
-          wget -N https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.14.sdk.tar.xz
-          tar xf MacOSX10.14.sdk.tar.xz
-          tar czf ${GITIAN_DIR}/inputs/MacOSX10.14.sdk.tar.gz MacOSX10.14.sdk
-          rm -rf MacOSX10.14.sdk MacOSX10.14.sdk.tar.xz
+        run: wget -N https://bitcoincore.org/depends-sources/sdks/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz -O ${GITIAN_DIR}/inputs/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -72,12 +68,12 @@ jobs:
         run: |
           DESCRIPTOR=$PWD/contrib/gitian-descriptors/gitian-${{ matrix.os }}.yml
           NAME=$(yq e '.name' ${DESCRIPTOR})
-          echo ::set-output name=descriptor::${DESCRIPTOR}
-          echo ::set-output name=name::${NAME}
-          echo ::set-output name=version::$(echo ${NAME} | grep -Eo [0-9.]+)
-          echo ::set-output name=suite::$(yq e '.suites[0]' ${DESCRIPTOR})
-          echo ::set-output name=architecture::$(yq e '.architectures[0]' ${DESCRIPTOR})
-          echo ::set-output name=build-dir::${PWD}
+          echo "descriptor=${DESCRIPTOR}" >> $GITHUB_OUTPUT
+          echo "name=${NAME}" >> $GITHUB_OUTPUT
+          echo "version=$(echo ${NAME} | grep -Eo [0-9.]+)" >> $GITHUB_OUTPUT 
+          echo "suite=$(yq e '.suites[0]' ${DESCRIPTOR})" >> $GITHUB_OUTPUT
+          echo "architecture=$(yq e '.architectures[0]' ${DESCRIPTOR})" >> $GITHUB_OUTPUT
+          echo "build-dir=${PWD}" >> $GITHUB_OUTPUT
 
       - name: Build gitian base image
         run: |
@@ -92,7 +88,7 @@ jobs:
           EOF
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: gitian-deps
         env:
           cache-name: gitian-host
@@ -119,9 +115,9 @@ jobs:
 
       - name: Get short SHA
         id: slug
-        run: echo ::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)
+        run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: peercoin-${{ steps.slug.outputs.sha8 }}-${{ matrix.name }}
           path: |
@@ -132,15 +128,16 @@ jobs:
             !*-debug*
             !*-unsigned.tar.gz
           retention-days: 5
+          if-no-files-found: error
   docker:
     runs-on: ubuntu-latest
     needs: [binary]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: peercoin/packaging
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: docker
 
@@ -185,8 +182,8 @@ jobs:
             TAG_NAME=${TAG_NAME/ppc/}
             TAG_NAME=${TAG_NAME/v/}
           fi
-          echo ::set-output name=push::${PUSH}
-          echo ::set-output name=tag-name::${TAG_NAME}
+          echo "push=${PUSH}" >> $GITHUB_OUTPUT
+          echo "tag-name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: Build and push
         working-directory: docker
@@ -220,11 +217,11 @@ jobs:
             sources_repo: http://archive.ubuntu.com/ubuntu
             apt_arch: amd64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: peercoin/packaging
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: appimage
 
@@ -247,9 +244,9 @@ jobs:
             TAG_NAME=${TAG_NAME/ppc/}
             TAG_NAME=${TAG_NAME/v/}
           fi
-          echo ::set-output name=sha8::$SHA8
-          echo ::set-output name=tag-name::$TAG_NAME
-          echo ::set-output name=build-dir::${PWD}
+          echo "sha8=$SHA8" >> $GITHUB_OUTPUT
+          echo "tag-name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "build-dir=${PWD}" >> $GITHUB_OUTPUT
 
       - name: Build AppImage
         working-directory: appimage
@@ -259,7 +256,7 @@ jobs:
           VERSION=${{ steps.detect.outputs.tag-name }} SOURCES_REPO=${{ matrix.sources_repo }} APT_ARCH=${{ matrix.apt_arch }} BUILD_ARCH=${{ matrix.name }} appimage-builder --skip-tests
           mv *.AppImage* ${{ steps.detect.outputs.build-dir }}/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: peercoin-appimage-${{ steps.detect.outputs.tag-name }}-${{ matrix.name }}
           path: |
@@ -289,24 +286,24 @@ jobs:
             TAG_NAME=noop
             RELEASE_TITLE=noop
           fi
-          echo ::set-output name=tag-name::$TAG_NAME
-          echo ::set-output name=release-title::"${RELEASE_TITLE}"
-          echo ::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)
+          echo "tag-name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "release-title=${RELEASE_TITLE}" >> $GITHUB_OUTPUT
+          echo "sha8=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT 
 
       - name: Set up environment
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
         run: sudo apt-get update && sudo apt-get install -y mktorrent gpg bash
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
 
       - name: Import GPG key
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v4
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
 
@@ -351,7 +348,7 @@ jobs:
           if ! git merge-base --is-ancestor refs/tags/latest HEAD; then
             PUBLISH=op
           fi
-          echo ::set-output name=publish::$PUBLISH
+          echo "publish=$PUBLISH" >> $GITHUB_OUTPUT
 
       - name: Generate Changelog
         if: ${{ steps.detect.outputs.tag-name != 'noop' && startsWith(github.ref, 'refs/tags/v') }}

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -135,12 +135,14 @@ MACHO_ALLOWED_LIBRARIES = {
 'CoreText', # interface for laying out text and handling fonts.
 'CoreVideo', # video processing
 'Foundation', # base layer functionality for apps/frameworks
+'GSS',
 'ImageIO', # read and write image file formats.
 'IOKit', # user-space access to hardware devices and drivers.
 'IOSurface', # cross process image/drawing buffers
 'libobjc.A.dylib', # Objective-C runtime library
 'Metal', # 3D graphics
 'Security', # access control and authentication
+'SystemConfiguration',
 'QuartzCore', # animation
 }
 

--- a/contrib/gitian-descriptors/assign_DISTNAME
+++ b/contrib/gitian-descriptors/assign_DISTNAME
@@ -1,0 +1,12 @@
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# A helper script to be sourced into the gitian descriptors
+
+if RECENT_TAG="$(git describe --exact-match HEAD 2> /dev/null)"; then
+    VERSION="${RECENT_TAG#v}"
+else
+    VERSION="$(git rev-parse --short=12 HEAD)"
+fi
+DISTNAME="peercoin-${VERSION}"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -32,7 +32,7 @@ remotes:
 - "url": "https://github.com/peercoin/peercoin.git"
   "dir": "peercoin"
 files:
-- "Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz"
+- "Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz"
 script: |
   set -e -o pipefail
 
@@ -90,7 +90,7 @@ script: |
   BASEPREFIX="${PWD}/depends"
 
   mkdir -p ${BASEPREFIX}/SDKs
-  tar -C ${BASEPREFIX}/SDKs -xf ${BUILD_DIR}/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz
+  tar -C ${BASEPREFIX}/SDKs -xf ${BUILD_DIR}/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz
 
   # Build dependencies for each host
   for i in $HOSTS; do


### PR DESCRIPTION
This PR fixes the the macos builds for `release-0.12`, and bumps dependency workflows.

However windows
https://github.com/ihavenoface/peercoin/actions/runs/3385021959/jobs/5622685046#step:10:1775
```
STRIPPROG="/home/ubuntu/wrapped/x86_64-w64-mingw32-strip" /bin/bash /home/ubuntu/build/peercoin/distsrc-x86_64-w64-mingw32/build-aux/install-sh -c -s ./src/peercoin-util.exe ./release
/home/ubuntu/build/peercoin/distsrc-x86_64-w64-mingw32/build-aux/install-sh: ./src/peercoin-util.exe does not exist.
make: *** [Makefile:1265: /home/ubuntu/out/peercoin-5b474e26e536-win64-setup-unsigned.exe] Error 1
```
and linux
https://github.com/ihavenoface/peercoin/actions/runs/3385021959/jobs/5622684823#step:10:1263
```
Running symbol and dynamic library checks...
peercoind: symbol getrandom from unsupported version GLIBC_2.25(9)
```
are throwing errors still. Those seem to be common issues however, and not related to the pipeline itself, so @backpacker69 could you take a look at those?
For linux I would be upping the MAX_VERSION in symbol-check, but that doesn't seem like the proper way to do it.