### PR TITLE
Rename bitcoin-util to peercoin-util

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,14 +144,20 @@ jobs:
       - name: Place artifacts
         working-directory: docker
         run: |
-          mkdir -p linux/amd64 linux/arm64 linux/arm/v7
+          mkdir -p linux/amd64 linux/arm/v7 linux/arm64
+          mv peercoin-*-x86_64-linux/peercoin-*-x86_64-linux-gnu.tar.gz linux/amd64/
           mv peercoin-*-armhf-linux/peercoin-*-arm-linux-gnueabihf.tar.gz linux/arm/v7/
           mv peercoin-*-aarch64-linux/peercoin-*-aarch64-linux-gnu.tar.gz linux/arm64/
-          mv peercoin-*-x86_64-linux/peercoin-*-x86_64-linux-gnu.tar.gz linux/amd64/
 
-      - uses: crazy-max/ghaction-docker-buildx@v1
+      - uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm,arm64
 
-      - uses: docker/login-action@v1
+      - uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -103,7 +103,7 @@ endif
 endif
 
 if BUILD_BITCOIN_UTIL
-  bin_PROGRAMS += bitcoin-util
+  bin_PROGRAMS += peercoin-util
 endif
 
 .PHONY: FORCE check-symbols check-security
@@ -748,16 +748,16 @@ endif
 #
 
 # bitcoin-util binary #
-bitcoin_util_SOURCES = bitcoin-util.cpp
-bitcoin_util_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
-bitcoin_util_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
-bitcoin_util_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS)
+peercoin_util_SOURCES = bitcoin-util.cpp
+peercoin_util_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+peercoin_util_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+peercoin_util_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS)
 
 if TARGET_WINDOWS
-bitcoin_util_SOURCES += bitcoin-util-res.rc
+peercoin_util_SOURCES += bitcoin-util-res.rc
 endif
 
-bitcoin_util_LDADD = \
+peercoin_util_LDADD = \
   $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_UTIL) \
   $(LIBUNIVALUE) \


### PR DESCRIPTION
This PR updates the naming scheme of bitcoin-util, so that the pipeline can find the resulting executable.

Other pipeline changes are being tested.