### PR TITLE
WIP: Various pipeline updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,15 +65,21 @@ jobs:
 
       - name: Detect suite
         id: detect
+        shell: bash
         run: |
           DESCRIPTOR=$PWD/contrib/gitian-descriptors/gitian-${{ matrix.os }}.yml
           NAME=$(yq e '.name' ${DESCRIPTOR})
+          COMMIT_OR_TAG=$(git log --format="%H" -n 1)
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            COMMIT_OR_TAG=$(echo ${GITHUB_REF/refs\/tags\//})
+          fi
           echo "descriptor=${DESCRIPTOR}" >> $GITHUB_OUTPUT
           echo "name=${NAME}" >> $GITHUB_OUTPUT
           echo "version=$(echo ${NAME} | grep -Eo [0-9.]+)" >> $GITHUB_OUTPUT 
           echo "suite=$(yq e '.suites[0]' ${DESCRIPTOR})" >> $GITHUB_OUTPUT
           echo "architecture=$(yq e '.architectures[0]' ${DESCRIPTOR})" >> $GITHUB_OUTPUT
           echo "build-dir=${PWD}" >> $GITHUB_OUTPUT
+          echo "commit-or-tag=${COMMIT_OR_TAG}" >> $GITHUB_OUTPUT
 
       - name: Build gitian base image
         run: |
@@ -96,21 +102,11 @@ jobs:
           path: ${{ env.GITIAN_CACHE }}/${{ steps.detect.outputs.name }}/${{ matrix.host }}
           key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('depends/packages/*') }}
 
-      - name: Change release description if tag
-        if: startsWith(github.ref, 'refs/tags/')
-        shell: bash
-        run: |
-          sed -i "s|^\(DESC=\"\).*|\1$(echo ${GITHUB_REF/refs\/tags\//})\"|" share/genbuild.sh
-          git config user.name temp
-          git config user.email temp@temp.com
-          git add share/genbuild.sh
-          git commit -m "Update DESC"
-
       - name: Build binary
         working-directory: ${{ env.GITIAN_DIR }}
         run: |
           sed -i "s/^\ \ \(HOSTS=\"\).*/\ \ \1${{ matrix.host }}\"/g" ${{ steps.detect.outputs.descriptor }}
-          ./bin/gbuild -j $MAKEJOBS --commit peercoin=$(git -C ${{ steps.detect.outputs.build-dir }} log --format="%H" -n 1) --url peercoin=${{ steps.detect.outputs.build-dir }} ${{ steps.detect.outputs.descriptor }}
+          ./bin/gbuild -j $MAKEJOBS --fetch-tags --commit peercoin=${{ steps.detect.outputs.commit-or-tag }} --url peercoin=${{ steps.detect.outputs.build-dir }} ${{ steps.detect.outputs.descriptor }}
           cp -r ${GITIAN_DIR}/build/out/* ${{ steps.detect.outputs.build-dir }}/
 
       - name: Get short SHA
@@ -279,9 +275,9 @@ jobs:
         run: |
           TAG_NAME=noop
           RELEASE_TITLE=noop
-          if [[ $GITHUB_REF == refs/heads/develop ]]; then
+          if [[ $GITHUB_REF == refs/heads/develop || $GITHUB_REF == refs/heads/release-* ]]; then
             TAG_NAME=latest
-            RELEASE_TITLE="Development Build"
+            RELEASE_TITLE="Development Build: ${GITHUB_REF/refs\/heads\//}"
           fi
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             TAG_NAME=${GITHUB_REF/refs\/tags\//}

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -24,6 +24,7 @@ packages:
 - "pkg-config"
 - "python3"
 - "python3-pip"
+- "pigz"
 # Cross compilation HOSTS:
 #  - arm-linux-gnueabihf
 - "binutils-arm-linux-gnueabihf"
@@ -49,7 +50,7 @@ script: |
 
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu riscv64-linux-gnu"
-  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests --disable-fuzz-binary"
+  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-tests --disable-gui-tests --disable-fuzz-binary --with-gui"
   FAKETIME_HOST_PROGS="gcc g++"
   FAKETIME_PROGS="date ar ranlib nm"
   HOST_CFLAGS="-O2 -g"
@@ -162,8 +163,8 @@ script: |
     find ${DISTNAME}/bin -type f -executable -print0 | xargs -0 -n1 -I{} ../contrib/devtools/split-debug.sh {} {} {}.dbg
     find ${DISTNAME}/lib -type f -print0 | xargs -0 -n1 -I{} ../contrib/devtools/split-debug.sh {} {} {}.dbg
     cp ../README.md ${DISTNAME}/
-    find ${DISTNAME} -not -name "*.dbg" | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
-    find ${DISTNAME} -name "*.dbg" | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}-debug.tar.gz
+    find ${DISTNAME} -not -name "*.dbg" | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | pigz -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    find ${DISTNAME} -name "*.dbg" | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | pigz -9n > ${OUTDIR}/${DISTNAME}-${i}-debug.tar.gz
     cd ../../
     rm -rf distsrc-${i}
   done

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -28,6 +28,7 @@ packages:
 - "fonts-tuffy"
 - "xorriso"
 - "libtinfo5"
+- "pigz"
 remotes:
 - "url": "https://github.com/peercoin/peercoin.git"
   "dir": "peercoin"
@@ -38,7 +39,7 @@ script: |
 
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin18"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --disable-fuzz-binary XORRISOFS=${WRAP_DIR}/xorrisofs DMG=${WRAP_DIR}/dmg"
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-tests --disable-gui-tests --disable-fuzz-binary --with-gui XORRISOFS=${WRAP_DIR}/xorrisofs DMG=${WRAP_DIR}/dmg"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="ar ranlib date dmg xorrisofs"
 
@@ -139,7 +140,7 @@ script: |
     cp ${BASEPREFIX}/${i}/native/bin/dmg unsigned-app-${i}
     mv dist unsigned-app-${i}
     pushd unsigned-app-${i}
-    find . | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-osx-unsigned.tar.gz
+    find . | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | pigz -9n > ${OUTDIR}/${DISTNAME}-osx-unsigned.tar.gz
     popd
 
     make deploy OSX_DMG="${OUTDIR}/${DISTNAME}-osx-unsigned.dmg"
@@ -148,7 +149,7 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
-    find ${DISTNAME} | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    find ${DISTNAME} | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | pigz -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
     cd ../../
   done
 

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -23,6 +23,7 @@ packages:
 - "ca-certificates"
 - "python3"
 - "python3-pip"
+- "pigz"
 remotes:
 - "url": "https://github.com/peercoin/peercoin.git"
   "dir": "peercoin"
@@ -32,7 +33,7 @@ script: |
 
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-w64-mingw32"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --disable-fuzz-binary"
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-tests --disable-gui-tests --disable-fuzz-binary --with-gui"
   FAKETIME_HOST_PROGS="ar ranlib nm windres strip objcopy"
   FAKETIME_PROGS="date makensis zip"
   HOST_CFLAGS="-O2 -g -fno-ident"
@@ -154,4 +155,4 @@ script: |
   cd $BUILD_DIR/windeploy
   mkdir unsigned
   cp ${OUTDIR}/${DISTNAME}-win64-setup-unsigned.exe unsigned/
-  find . | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz
+  find . | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | pigz -9n > ${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz


### PR DESCRIPTION
This PR updates a couple of things:  
First we drop building tests entirely. While we _should_ use them, we currently don't, so might as well disable them for some time savings.

Then, we get rid of the in-place genbuild update. Instead we just tell gitian to pull tags when needed. Much cleaner.

Further, we add `--with-gui` as a config flag, so that we can exit more reliably in case qt is acting up again.

We also allow `release-*` branches to push development builds to the release page, similar to what `develop` is doing now.

Lastly, replace `gzip` with `pigz`. Again for more time savings (single vs multi core archival).