### PR TITLE
build: publish to dockerhub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,12 +154,6 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
 
-      - uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
       - name: Detect env
         id: detect
         shell: bash
@@ -168,11 +162,11 @@ jobs:
           TAG_NAME=blank
           if [[ $GITHUB_REF == refs/heads/develop ]]; then
             PUSH=true
-            TAG_NAME=latest
+            TAG_NAME=develop
           fi
           if [[ $GITHUB_REF == refs/heads/master ]]; then
             PUSH=true
-            TAG_NAME=master
+            TAG_NAME=latest
           fi
           if [[ $GITHUB_REF == refs/heads/release-* ]]; then
             PUSH=true
@@ -188,12 +182,28 @@ jobs:
           echo "push=${PUSH}" >> $GITHUB_OUTPUT
           echo "tag-name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        if: steps.detect.outputs.push == 'true'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        if: steps.detect.outputs.push == 'true'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Build and push
         working-directory: docker
         run: |
           docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64 \
             --output "type=image,push=${{ steps.detect.outputs.push }}" \
             --progress=plain \
+            --tag peercoin/peercoind:${{ steps.detect.outputs.tag-name }} \
             --tag ghcr.io/${{ github.repository }}/peercoind:${{ steps.detect.outputs.tag-name }} \
           .
   appimage:


### PR DESCRIPTION
This PR will enable docker hub as a target. Multi arch is supported.  
Two things would be required first:
- Merge https://github.com/peercoin/packaging/pull/21 for a better base image
- Set up `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in the repo secrets