### PR TITLE
Remove unused getPruneMiB() declaration

### DIFF
--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -36,7 +36,6 @@ public:
 
     QString getDataDirectory();
     void setDataDirectory(const QString &dataDir);
-    int64_t getPruneMiB() const;
 
     /**
      * Determine data directory. Let the user choose if the current one doesn't exist.


### PR DESCRIPTION
getPruneMiB() definition has been removed, so its declaration should be removed as well.