### PR TITLE
Do not process blocks without data during UTXO snapshot load

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3845,6 +3845,12 @@ bool CVerifyDB::VerifyDB(
         if (pindex->nHeight <= chainstate.m_chain.Height() - nCheckDepth) {
             break;
         }
+        if (is_snapshot_cs && !(pindex->nStatus & BLOCK_HAVE_DATA)) {
+            // If running under an assumeutxo snapshot, only go
+            // back as far as we have data.
+            LogPrintf("VerifyDB(): block verification stopping at height %d (no data)\n", pindex->nHeight);
+            break;
+        }
         CBlock block;
         // check level 0: read from disk
         if (!ReadBlockFromDisk(block, pindex, consensus_params)) {


### PR DESCRIPTION
When loading UTXO snapshot, it seems logical to check if there is BLOCK_HAVE_DATA status.
I believe this check has been accidentally removed while removing pruning code.