### PR TITLE
Use correct Peercoin Github URL

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -95,7 +95,7 @@ std::string CopyrightHolders(const std::string& strPrefix)
 
 std::string LicenseInfo()
 {
-    const std::string URL_SOURCE_CODE = "<https://github.com/bitcoin/bitcoin>";
+    const std::string URL_SOURCE_CODE = "<https://github.com/peercoin/peercoin>";
 
     return CopyrightHolders(strprintf(_("Copyright (C) %i-%i").translated, 2009, COPYRIGHT_YEAR) + " ") + "\n" +
            "\n" +


### PR DESCRIPTION
In "About Peercoin" window there is Bitcoin Github URL at moment. It shouldn't be so.