### PR TITLE
Remove pruning residue in WalletController::closeWallet()

### DIFF
--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -82,7 +82,6 @@ void WalletController::closeWallet(WalletModel* wallet_model, QWidget* parent)
     QMessageBox box(parent);
     box.setWindowTitle(tr("Close wallet"));
     box.setText(tr("Are you sure you wish to close the wallet <i>%1</i>?").arg(GUIUtil::HtmlEscape(wallet_model->getDisplayName())));
-    box.setInformativeText(tr("Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled."));
     box.setStandardButtons(QMessageBox::Yes|QMessageBox::Cancel);
     box.setDefaultButton(QMessageBox::Yes);
     if (box.exec() != QMessageBox::Yes) return;


### PR DESCRIPTION
This PR removes pruning reference in the dialog windows that appears on wallet close.