### PR TITLE
Remove unused FeeCalculation declarations

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -26,7 +26,6 @@ class uint256;
 enum class MemPoolRemovalReason;
 struct bilingual_str;
 struct CBlockLocator;
-struct FeeCalculation;
 namespace node {
 struct NodeContext;
 } // namespace node

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -47,7 +47,6 @@ using LoadWalletFn = std::function<void(std::unique_ptr<interfaces::Wallet> wall
 
 class CScript;
 enum class FeeEstimateMode;
-struct FeeCalculation;
 struct bilingual_str;
 
 namespace wallet {


### PR DESCRIPTION
FeeCalculation struct is not used by Peercoin anymore. so its declarations should be removed.