### PR TITLE
Fix errors in message capture parser

### DIFF
--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -504,7 +504,7 @@ class CTxWitness:
 
 
 class CTransaction:
-    __slots__ = ("hash", "nLockTime", "nVersion", "sha256", "vin", "vout",
+    __slots__ = ("hash", "nLockTime", "nVersion", "nTime", "sha256", "vin", "vout",
                  "wit")
 
     def __init__(self, tx=None):
@@ -529,7 +529,8 @@ class CTransaction:
 
     def deserialize(self, f):
         self.nVersion = struct.unpack("<i", f.read(4))[0]
-        self.nTime = struct.unpack("<I", f.read(4))[0]
+        if self.nVersion < 3:
+            self.nTime = struct.unpack("<I", f.read(4))[0]
         self.vin = deser_vector(f, CTxIn)
         flags = 0
         if len(self.vin) == 0:
@@ -553,7 +554,8 @@ class CTransaction:
     def serialize_without_witness(self):
         r = b""
         r += struct.pack("<i", self.nVersion)
-        r += struct.pack("<I", self.nTime)
+        if self.nVersion < 3:
+            r += struct.pack("<I", self.nTime)
         r += ser_vector(self.vin)
         r += ser_vector(self.vout)
         r += struct.pack("<I", self.nLockTime)
@@ -566,7 +568,8 @@ class CTransaction:
             flags |= 1
         r = b""
         r += struct.pack("<i", self.nVersion)
-        r += struct.pack("<I", self.nTime)
+        if self.nVersion < 3:
+            r += struct.pack("<I", self.nTime)
         if flags:
             dummy = []
             r += ser_vector(dummy)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -631,7 +631,7 @@ class CTransaction:
 
 
 class CBlockHeader:
-    __slots__ = ("hash", "hashMerkleRoot", "hashPrevBlock", "nBits", "nNonce",
+    __slots__ = ("hash", "hashMerkleRoot", "hashPrevBlock", "nBits", "nNonce", "nFlags",
                  "nTime", "nVersion", "sha256")
 
     def __init__(self, header=None):
@@ -644,9 +644,9 @@ class CBlockHeader:
             self.nTime = header.nTime
             self.nBits = header.nBits
             self.nNonce = header.nNonce
+            self.nFlags = header.nFlags
             self.sha256 = header.sha256
             self.hash = header.hash
-            self.nFlags = header.nFlags
             self.calc_sha256()
 
     def set_null(self):
@@ -667,6 +667,7 @@ class CBlockHeader:
         self.nTime = struct.unpack("<I", f.read(4))[0]
         self.nBits = struct.unpack("<I", f.read(4))[0]
         self.nNonce = struct.unpack("<I", f.read(4))[0]
+        self.nFlags = struct.unpack("<I", f.read(4))[0]
         self.sha256 = None
         self.hash = None
 
@@ -678,6 +679,7 @@ class CBlockHeader:
         r += struct.pack("<I", self.nTime)
         r += struct.pack("<I", self.nBits)
         r += struct.pack("<I", self.nNonce)
+        r += struct.pack("<I", self.nFlags)
         return r
 
     def calc_sha256(self):
@@ -698,12 +700,12 @@ class CBlockHeader:
         return self.sha256
 
     def __repr__(self):
-        return "CBlockHeader(nVersion=%i hashPrevBlock=%064x hashMerkleRoot=%064x nTime=%s nBits=%08x nNonce=%08x)" \
+        return "CBlockHeader(nVersion=%i hashPrevBlock=%064x hashMerkleRoot=%064x nTime=%s nBits=%08x nNonce=%08x nFlags=%08x)" \
             % (self.nVersion, self.hashPrevBlock, self.hashMerkleRoot,
-               time.ctime(self.nTime), self.nBits, self.nNonce)
+               time.ctime(self.nTime), self.nBits, self.nNonce, self.nFlags)
 
 BLOCK_HEADER_SIZE = len(CBlockHeader().serialize())
-assert_equal(BLOCK_HEADER_SIZE, 80)
+assert_equal(BLOCK_HEADER_SIZE, 84)
 
 class CBlock(CBlockHeader):
     __slots__ = ("vtx", "vchBlockSig",)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -706,7 +706,7 @@ BLOCK_HEADER_SIZE = len(CBlockHeader().serialize())
 assert_equal(BLOCK_HEADER_SIZE, 80)
 
 class CBlock(CBlockHeader):
-    __slots__ = ("vtx",)
+    __slots__ = ("vtx", "vchBlockSig",)
 
     def __init__(self, header=None):
         super().__init__(header)
@@ -784,9 +784,9 @@ class CBlock(CBlockHeader):
         return (WITNESS_SCALE_FACTOR - 1) * without_witness_size + with_witness_size
 
     def __repr__(self):
-        return "CBlock(nVersion=%i hashPrevBlock=%064x hashMerkleRoot=%064x nTime=%s nBits=%08x nNonce=%08x vtx=%s)" \
+        return "CBlock(nVersion=%i hashPrevBlock=%064x hashMerkleRoot=%064x nTime=%s nBits=%08x nNonce=%08x vtx=%s vtx=%s)" \
             % (self.nVersion, self.hashPrevBlock, self.hashMerkleRoot,
-               time.ctime(self.nTime), self.nBits, self.nNonce, repr(self.vtx))
+               time.ctime(self.nTime), self.nBits, self.nNonce, repr(self.vtx), repr(self.vchBlockSig))
 
 
 class PrefilledTransaction:


### PR DESCRIPTION
This PR fixes issues in `CBlockHeader`, `CBlock`  and `CTransaction` classes in test framework that prevented message capture parser from parsing network messages sent/received by Peercoin nodes.
Now it is possible to capture messages by using -messagecapture flag and parse the output with the help of `contrib/message-capture/message-capture-parser.py` Python script.
