### PR TITLE
enable riscv64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         name:
           - armhf-linux
           - aarch64-linux
+          - riscv64-linux
           - x86_64-linux
           - x86_64-macos
           - x86_64-win
@@ -37,6 +38,9 @@ jobs:
           - os: linux
             name: aarch64-linux
             host: aarch64-linux-gnu
+          - os: linux
+            name: riscv64-linux
+            host: riscv64-linux-gnu
           - os: linux
             name: x86_64-linux
             host: x86_64-linux-gnu


### PR DESCRIPTION
Docker base images / appimage for riscv64 aren't readily available anymore, so only the regular format needs to suffice.