### PR TITLE
Do not start staking thread if the keypool is empty

### DIFF
--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -719,6 +719,11 @@ void static ThreadStakeMinter(std::shared_ptr<CWallet> pwallet, NodeContext& m_n
 // peercoin: stake minter
 void MintStake(std::shared_ptr<CWallet> pwallet, NodeContext& m_node)
 {
+    if (!pwallet->GetKeyPoolSize()) {
+        LogPrintf("Error: Keypool is empty, please make sure the wallet contains keys and call keypoolrefill before restarting the mining thread\n");
+        return;
+    }
+
     m_minter_thread = std::thread([&] { util::TraceThread("minter", [&] { ThreadStakeMinter(pwallet, m_node); }); });
 }
 } // namespace node


### PR DESCRIPTION
It makes no sense to start staking if there are no keys in the keypool.