### PR TITLE
Remove unused nPruneAfterHeight variable

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -102,7 +102,6 @@ public:
         pchMessageStart[2] = 0xe9;
         pchMessageStart[3] = 0xe5;
         nDefaultPort = 9901;
-        nPruneAfterHeight = 100000;
         m_assumed_blockchain_size = 2;
 
         genesis = CreateGenesisBlock(1345083810, 1345084287, 2179302059u, 0x1d00ffff, 1, 0);
@@ -209,7 +208,6 @@ public:
         pchMessageStart[2] = 0xc0;
         pchMessageStart[3] = 0xef;
         nDefaultPort = 9903;
-        nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 1;
 
         genesis = CreateGenesisBlock(1345083810, 1345090000, 122894938, 0x1d0fffff, 1, 0);
@@ -355,7 +353,6 @@ public:
         memcpy(pchMessageStart, hash.begin(), 4);
 
         nDefaultPort = 38333;
-        nPruneAfterHeight = 1000;
 
         genesis = CreateGenesisBlock(1345083810, 1345090000, 122894938, 0x1d0fffff, 1, 0);
         consensus.hashGenesisBlock = genesis.GetHash();
@@ -441,7 +438,6 @@ public:
         pchMessageStart[2] = 0xc0;
         pchMessageStart[3] = 0xef;
         nDefaultPort = 9903;
-        nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 0;
 
         genesis = CreateGenesisBlock(1345083810, 1345090000, 122894938, 0x1d0fffff, 1, 0);

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -142,7 +142,6 @@ public:
         pchMessageStart[2] = 0xe9;
         pchMessageStart[3] = 0xe5;
         nDefaultPort = 9901;
-        nPruneAfterHeight = 100000;
         m_assumed_blockchain_size = 2;
 
         genesis = CreateGenesisBlock(1345083810, 1345084287, 2179302059u, 0x1d00ffff, 1, 0);
@@ -247,7 +246,6 @@ public:
         pchMessageStart[2] = 0xc0;
         pchMessageStart[3] = 0xef;
         nDefaultPort = 9903;
-        nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 1;
 
         genesis = CreateGenesisBlock(1345083810, 1345090000, 122894938, 0x1d0fffff, 1, 0);
@@ -398,7 +396,6 @@ public:
         memcpy(pchMessageStart, hash.begin(), 4);
 
         nDefaultPort = 38333;
-        nPruneAfterHeight = 1000;
 
         genesis = CreateGenesisBlock(1345083810, 1345090000, 122894938, 0x1d0fffff, 1, 0);
         consensus.hashGenesisBlock = genesis.GetHash();
@@ -468,7 +465,6 @@ public:
         pchMessageStart[2] = 0xb5;
         pchMessageStart[3] = 0xda;
         nDefaultPort = 18444;
-        nPruneAfterHeight = opts.fastprune ? 100 : 1000;
         m_assumed_blockchain_size = 0;
         m_assumed_chain_state_size = 0;
 

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -109,7 +109,6 @@ public:
     bool IsTestChain() const { return m_is_test_chain; }
     /** If this chain allows time to be mocked */
     bool IsMockableChain() const { return m_is_mockable_chain; }
-    uint64_t PruneAfterHeight() const { return nPruneAfterHeight; }
     /** Minimum free space (in GB) needed for data directory */
     uint64_t AssumedBlockchainSize() const { return m_assumed_blockchain_size; }
     /** Minimum free space (in GB) needed for data directory when pruned; Does not include prune target*/
@@ -168,7 +167,6 @@ protected:
     Consensus::Params consensus;
     CMessageHeader::MessageStartChars pchMessageStart;
     uint16_t nDefaultPort;
-    uint64_t nPruneAfterHeight;
     uint64_t m_assumed_blockchain_size;
     uint64_t m_assumed_chain_state_size;
     std::vector<std::string> vSeeds;


### PR DESCRIPTION
nPruneAfterHeight is not used anymore and has to be completely removed.