### PR TITLE
remove redundant declarations

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -309,13 +309,6 @@ enum ServiceFlags : uint64_t {
 std::vector<std::string> serviceFlagsToStr(uint64_t flags);
 
 /**
- * Convert service flags (a bitmask of NODE_*) to human readable strings.
- * It supports unknown service flags which will be returned as "UNKNOWN[...]".
- * @param[in] flags multiple NODE_* bitwise-OR-ed together
- */
-std::vector<std::string> serviceFlagsToStr(uint64_t flags);
-
-/**
  * Gets the set of service flags which are "desirable" for a given peer.
  *
  * These are the flags which are required for a peer to support for them

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -1235,9 +1235,6 @@ bool SignPSBTInput(const SigningProvider& provider, PartiallySignedTransaction& 
 /** Counts the unsigned inputs of a PSBT. */
 size_t CountPSBTUnsignedInputs(const PartiallySignedTransaction& psbt);
 
-/** Counts the unsigned inputs of a PSBT. */
-size_t CountPSBTUnsignedInputs(const PartiallySignedTransaction& psbt);
-
 /** Updates a PSBTOutput with information from provider.
  *
  * This fills in the redeem_script, witness_script, and hd_keypaths where possible.

--- a/src/test/torcontrol_tests.cpp
+++ b/src/test/torcontrol_tests.cpp
@@ -13,9 +13,6 @@
 std::pair<std::string, std::string> SplitTorReplyLine(const std::string& s);
 std::map<std::string, std::string> ParseTorReplyMapping(const std::string& s);
 
-std::pair<std::string, std::string> SplitTorReplyLine(const std::string& s);
-std::map<std::string, std::string> ParseTorReplyMapping(const std::string& s);
-
 BOOST_AUTO_TEST_SUITE(torcontrol_tests)
 
 static void CheckSplitTorReplyLine(std::string input, std::string command, std::string args)

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -22,9 +22,6 @@ struct NodeContext;
 /** Create a blockchain, starting from genesis */
 std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const CChainParams& params);
 
-/** Create a blockchain, starting from genesis */
-std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const CChainParams& params);
-
 /** Returns the generated coin */
 CTxIn MineBlock(const node::NodeContext&, const CScript& coinbase_scriptPubKey);
 

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -405,15 +405,6 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
  */
 std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, FastRandomContext& rng);
 
-/** Select coins by Single Random Draw. OutputGroups are selected randomly from the eligible
- * outputs until the target is satisfied
- *
- * @param[in]  utxo_pool    The positive effective value OutputGroups eligible for selection
- * @param[in]  target_value The target value to select for
- * @returns If successful, a pair of set of outputs and total selected value, otherwise, std::nullopt
- */
-std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value, FastRandomContext& rng);
-
 // Original coin selection algorithm as a fallback
 std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue,
                                               CAmount change_target, FastRandomContext& rng);


### PR DESCRIPTION

warnings are generated e.g.

                 from ./chainparams.h:9,
                 from test/blockmanager_tests.cpp:5:
./protocol.h:316:26: warning: redundant redeclaration of ‘std::vector<std::__cxx11::basic_string<char> > serviceFlagsToStr(uint64_t)’ in same scope [-Wredundant-decls]
  316 | std::vector<std::string> serviceFlagsToStr(uint64_t flags);
      |                          ^~~~~~~~~~~~~~~~~
./protocol.h:309:26: note: previous declaration of ‘std::vector<std::__cxx11::basic_string<char> > serviceFlagsToStr(uint64_t)’
  309 | std::vector<std::string> serviceFlagsToStr(uint64_t flags);
      | 