### PR TITLE
Construct a new SignatureData object  for each pcoin

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3830,11 +3830,11 @@ bool CWallet::CreateCoinStake(ChainstateManager& chainman, const CWallet* pwalle
 
         // Sign
         int nIn = 0;
-        SignatureData empty;
 
         if (IsLegacy()) {
             for (const auto& pcoin : vwtxPrev)
             {
+                SignatureData empty;
                 if (!SignSignature(*pwallet->GetLegacyScriptPubKeyMan(), *pcoin, txNew, nIn++, SIGHASH_ALL, empty))
                     return error("CreateCoinStake : failed to sign coinstake");
             }


### PR DESCRIPTION
A unique `SignatureData` object should be created on each iteration of the loop; otherwise, it leads to incorrect signatures.
The bug has been described before on Discord.