### PR TITLE
Replace gitian with guix in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,111 +10,123 @@ on:
       - 'contrib/**'
       - '**/*.md'
 
-env:
-  MAKEJOBS: 3
-  DOCKER_BUILDKIT: 1
-  GITIAN_DIR: /opt/gitian-builder
-  GITIAN_CACHE: /opt/gitian-builder/cache
-  DEBIAN_FRONTEND: noninteractive
-  USE_DOCKER: 1
-
 jobs:
   binary:
-    runs-on: ubuntu-20.04
-    container: docker:stable-dind
+    runs-on: ubuntu-22.04
+    container:
+      image: alpine:3.19
+      options: --privileged
+    env:
+      guix_download_path: ftp://ftp.gnu.org/gnu/guix
+      guix_version: 1.4.0
+      guix_checksum_aarch64: 72d807392889919940b7ec9632c45a259555e6b0942ea7bfd131101e08ebfcf4
+      guix_checksum_x86_64: 236ca7c9c5958b1f396c2924fcc5bc9d6fdebcb1b4cf3c7c6d46d4bf660ed9c9
+      xcode_download_path: https://bitcoincore.org/depends-sources/sdks/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz
+      xcode_checksum: df75d30ecafc429e905134333aeae56ac65fac67cb4182622398fd717df77619
+      builder_count: 32
+      GUIX_LOCPATH: /root/.guix-profile/lib/locale
+      LC_ALL: en_US.UTF-8
+      HOSTS: ${{ matrix.name }}
+      SUBSTITUTE_URLS: https://ci.guix.gnu.org
+
     strategy:
       matrix:
         name:
-          - armhf-linux
-          - aarch64-linux
-          - x86_64-linux
-          - x86_64-macos
-          - x86_64-win
-        include:
-          - os: linux
-            name: armhf-linux
-            host: arm-linux-gnueabihf
-          - os: linux
-            name: aarch64-linux
-            host: aarch64-linux-gnu
-          - os: linux
-            name: x86_64-linux
-            host: x86_64-linux-gnu
-          - os: osx
-            name: x86_64-macos
-            host: x86_64-apple-darwin16
-          - os: win
-            name: x86_64-win
-            host: x86_64-w64-mingw32
+          - x86_64-linux-gnu
+          - arm-linux-gnueabihf
+          - aarch64-linux-gnu
+          - riscv64-linux-gnu
+          - x86_64-w64-mingw32
+          - x86_64-apple-darwin
+          - arm64-apple-darwin
+
     steps:
-      - name: Set up environment
+      - run: >
+          apk --update add
+          nodejs-current
+          wget
+          zstd
+          bash
+          bzip2
+          ca-certificates
+          curl
+          git
+          make
+          shadow
+
+      - name: Set up guix
         run: |
-          apk add --no-cache curl make ruby wget git sed tar grep bash
-          git clone https://github.com/devrandom/gitian-builder.git ${GITIAN_DIR}
-          mkdir -p ${GITIAN_DIR}/inputs ${GITIAN_DIR}/var
-          wget https://github.com/mikefarah/yq/releases/download/v4.13.5/yq_linux_amd64.tar.gz -O - |\
-            tar xz && mv yq_linux_amd64 /usr/bin/yq
+          guix_file_name=guix-binary-${guix_version}.$(uname -m)-linux.tar.xz
+          eval "guix_checksum=\${guix_checksum_$(uname -m)}"
+          cd /tmp
+          wget -q -O "$guix_file_name" "${guix_download_path}/${guix_file_name}"
+          echo "${guix_checksum}  ${guix_file_name}" | sha256sum -c
+          tar xJf "$guix_file_name"
+          mv var/guix /var/
+          mv gnu /
+          mkdir -p ~root/.config/guix
+          ln -sf /var/guix/profiles/per-user/root/current-guix ~root/.config/guix/current
+          source ~root/.config/guix/current/etc/profile
 
-      - name: Fetch OSX SDK
-        if: ${{ matrix.os == 'osx' }}
-        run: wget -N https://bitcoincore.org/depends-sources/sdks/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz -O ${GITIAN_DIR}/inputs/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz
+      - run: echo "/root/.config/guix/current/bin" >> $GITHUB_PATH
 
-      - uses: actions/checkout@v3
+      - run: touch /etc/nsswitch.conf
 
-      - name: Detect suite
-        id: detect
-        shell: bash
-        run: |
-          DESCRIPTOR=$PWD/contrib/gitian-descriptors/gitian-${{ matrix.os }}.yml
-          NAME=$(yq e '.name' ${DESCRIPTOR})
-          COMMIT_OR_TAG=$(git log --format="%H" -n 1)
-          FETCH_TAGS=""
-          if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            COMMIT_OR_TAG=$(echo ${GITHUB_REF/refs\/tags\//})
-            FETCH_TAGS="--fetch-tags"
-          fi
-          echo "descriptor=${DESCRIPTOR}" >> $GITHUB_OUTPUT
-          echo "name=${NAME}" >> $GITHUB_OUTPUT
-          echo "version=$(echo ${NAME} | grep -Eo [0-9.]+)" >> $GITHUB_OUTPUT
-          echo "suite=$(yq e '.suites[0]' ${DESCRIPTOR})" >> $GITHUB_OUTPUT
-          echo "architecture=$(yq e '.architectures[0]' ${DESCRIPTOR})" >> $GITHUB_OUTPUT
-          echo "build-dir=${PWD}" >> $GITHUB_OUTPUT
-          echo "commit-or-tag=${COMMIT_OR_TAG}" >> $GITHUB_OUTPUT
-          echo "fetch-tags=${FETCH_TAGS}" >> $GITHUB_OUTPUT
+      - run: guix archive --authorize < ~root/.config/guix/current/share/guix/ci.guix.gnu.org.pub
 
-      - name: Build gitian base image
-        run: |
-          docker build --tag base-${{ steps.detect.outputs.suite }}-${{ steps.detect.outputs.architecture }} -<<EOF
-            FROM ubuntu:${{ steps.detect.outputs.suite }}
-            ENV DEBIAN_FRONTEND=noninteractive
-            RUN apt-get update && apt-get --no-install-recommends -y install pciutils build-essential git subversion language-pack-en wget lsb-release
-            RUN useradd -ms /bin/bash -U ubuntu
-            USER ubuntu:ubuntu
-            WORKDIR /home/ubuntu
-            CMD ["sleep", "infinity"]
-          EOF
+      - run: groupadd --system guixbuild
 
+      - run: |
+          for i in $(seq -w 1 ${builder_count}); do \
+            useradd -g guixbuild -G guixbuild \
+                    -d /var/empty -s $(which nologin) \
+                    -c "Guix build user ${i}" --system \
+                    "guixbuilder${i}" ; \
+          done
+
+      - uses: actions/checkout@v4
+      - run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+      - run: apk add tar
       - name: Cache dependencies
-        uses: actions/cache@v3
-        id: gitian-deps
+        uses: actions/cache@v4
+        id: depends
         env:
-          cache-name: gitian-host
+          cache-name: guix-host
         with:
-          path: ${{ env.GITIAN_CACHE }}/${{ steps.detect.outputs.name }}/${{ matrix.host }}
+          path: depends/built/${{ matrix.host }}
           key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('depends/packages/*') }}
 
-      - name: Build binary
-        working-directory: ${{ env.GITIAN_DIR }}
+      - name: Fetch OSX SDK
+        if: ${{ matrix.name == 'x86_64-apple-darwin' || matrix.name == 'arm64-apple-darwin' }}
+        working-directory: /tmp
         run: |
-          sed -i "s/^\ \ \(HOSTS=\"\).*/\ \ \1${{ matrix.host }}\"/g" ${{ steps.detect.outputs.descriptor }}
-          ./bin/gbuild -j $MAKEJOBS ${{ steps.detect.outputs.fetch-tags }} --commit peercoin=${{ steps.detect.outputs.commit-or-tag }} --url peercoin=${{ github.server_url }}/${{ github.repository }} ${{ steps.detect.outputs.descriptor }}
-          cp -r ${GITIAN_DIR}/build/out/* ${{ steps.detect.outputs.build-dir }}/
+          wget -q -O xcode.tar.gz ${xcode_download_path}
+          echo "${xcode_checksum} xcode.tar.gz" | sha256sum -c
+
+      - name: Extract OSX SDK
+        if: ${{ matrix.name == 'x86_64-apple-darwin' || matrix.name == 'arm64-apple-darwin' }}
+        run: |
+          mkdir depends/SDKs
+          tar -C depends/SDKs -xaf /tmp/xcode.tar.gz
+
+      - run: guix-daemon --build-users-group=guixbuild & ./contrib/guix/guix-build
+
+      - shell: bash
+        id: detect-outdir
+        run: |
+          source "contrib/guix/libexec/prelude.bash"
+          export OUTDIR_BASE="${OUTDIR_BASE:-${VERSION_BASE}/output}"
+          echo "outdir=${OUTDIR_BASE}/${1}${2:+-${2}}/${{ matrix.name }}" >> $GITHUB_OUTPUT
 
       - name: Get short SHA
         id: slug
         run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v3
+      - name: Copy artifacts
+        run: cp -r ${{ steps.detect-outdir.outputs.outdir }}/* ${PWD}/
+
+      - uses: actions/upload-artifact@v4
         with:
           name: peercoin-${{ steps.slug.outputs.sha8 }}-${{ matrix.name }}
           path: |
@@ -127,14 +139,14 @@ jobs:
           retention-days: 5
           if-no-files-found: error
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [binary]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: peercoin/packaging
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: docker
 
@@ -142,15 +154,15 @@ jobs:
         working-directory: docker
         run: |
           mkdir -p linux/amd64 linux/arm/v7 linux/arm64
-          mv peercoin-*-x86_64-linux/peercoin-*-x86_64-linux-gnu.tar.gz linux/amd64/
-          mv peercoin-*-armhf-linux/peercoin-*-arm-linux-gnueabihf.tar.gz linux/arm/v7/
-          mv peercoin-*-aarch64-linux/peercoin-*-aarch64-linux-gnu.tar.gz linux/arm64/
+          mv peercoin-*-x86_64-linux-gnu/peercoin-*-x86_64-linux-gnu.tar.gz linux/amd64/
+          mv peercoin-*-arm-linux-gnueabihf/peercoin-*-arm-linux-gnueabihf.tar.gz linux/arm/v7/
+          mv peercoin-*-aarch64-linux-gnu/peercoin-*-aarch64-linux-gnu.tar.gz linux/arm64/
 
-      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-qemu-action@v3
         with:
           platforms: arm,arm64
 
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
 
@@ -183,14 +195,14 @@ jobs:
           echo "tag-name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: steps.detect.outputs.push == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: steps.detect.outputs.push == 'true'
         with:
           registry: ghcr.io
@@ -207,7 +219,7 @@ jobs:
             --tag ghcr.io/${{ github.repository }}/peercoind:${{ steps.detect.outputs.tag-name }} \
           .
   appimage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [binary]
     strategy:
       matrix:
@@ -229,18 +241,17 @@ jobs:
             sources_repo: http://archive.ubuntu.com/ubuntu
             apt_arch: amd64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: peercoin/packaging
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: appimage
 
       - name: Set up environment
         working-directory: appimage
-        run: |
-          pip3 install --upgrade pyOpenSSL git+https://github.com/AppImageCrafters/appimage-builder@3396839c9e3419f4bd726cb129e54e6da4212e48
+        run: pip3 install --upgrade pyOpenSSL git+https://github.com/AppImageCrafters/appimage-builder@3396839c9e3419f4bd726cb129e54e6da4212e48
 
       - name: Detect env
         id: detect
@@ -261,19 +272,19 @@ jobs:
       - name: Build AppImage
         working-directory: appimage
         run: |
-          tar xzf peercoin-${{ steps.detect.outputs.sha8 }}-${{ matrix.name }}-linux/peercoin-*-${{ matrix.host }}.tar.gz -C AppDir --strip-components=1
+          tar xzf peercoin-${{ steps.detect.outputs.sha8 }}-${{ matrix.host }}/peercoin-*-${{ matrix.host }}.tar.gz -C AppDir --strip-components=1
           find AppDir/bin ! -name 'peercoin-qt' -type f -exec rm -f {} +
           VERSION=${{ steps.detect.outputs.tag-name }} SOURCES_REPO=${{ matrix.sources_repo }} APT_ARCH=${{ matrix.apt_arch }} BUILD_ARCH=${{ matrix.name }} appimage-builder --skip-tests
           mv *.AppImage ${{ steps.detect.outputs.build-dir }}/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: peercoin-appimage-${{ steps.detect.outputs.tag-name }}-${{ matrix.name }}
           path: |
             *.AppImage
           retention-days: 5
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [binary, appimage]
     if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release-') }}
     steps:
@@ -304,16 +315,16 @@ jobs:
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
         run: sudo apt-get update && sudo apt-get install -y mktorrent gpg bash
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
 
       - name: Import GPG key
         if: ${{ steps.detect.outputs.tag-name != 'noop' }}
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
 

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -157,7 +157,7 @@ done
 if (( total_required_KiB > avail_KiB )); then
     total_required_GiB=$((total_required_KiB / 1048576))
     avail_GiB=$((avail_KiB / 1048576))
-    echo "Performing a Bitcoin Core Guix build for the selected HOSTS requires ${total_required_GiB} GiB, however, only ${avail_GiB} GiB is available. Please free up some disk space before performing the build."
+    echo "Performing a Peercoin Guix build for the selected HOSTS requires ${total_required_GiB} GiB, however, only ${avail_GiB} GiB is available. Please free up some disk space before performing the build."
     exit 1
 fi
 
@@ -337,7 +337,7 @@ output directory.
 EOF
 }
 
-# Deterministically build Bitcoin Core
+# Deterministically build Peercoin
 # shellcheck disable=SC2153
 for host in $HOSTS; do
 
@@ -355,7 +355,7 @@ INFO: Building ${VERSION:?not set} for platform triple ${HOST:?not set}:
       ...using reference timestamp: ${SOURCE_DATE_EPOCH:?not set}
       ...running at most ${JOBS:?not set} jobs
       ...from worktree directory: '${PWD}'
-          ...bind-mounted in container to: '/bitcoin'
+          ...bind-mounted in container to: '/peercoin'
       ...in build directory: '$(distsrc_for_host "$HOST")'
           ...bind-mounted in container to: '$(DISTSRC_BASE=/distsrc-base && distsrc_for_host "$HOST")'
       ...outputting in: '$(outdir_for_host "$HOST")'
@@ -381,24 +381,24 @@ EOF
         #
         #     When --container is specified, the default behavior is to share
         #     the current working directory with the isolated container at the
-        #     same exact path (e.g. mapping '/home/satoshi/bitcoin/' to
-        #     '/home/satoshi/bitcoin/'). This means that the $PWD inside the
+        #     same exact path (e.g. mapping '/home/satoshi/peercoin/' to
+        #     '/home/satoshi/peercoin/'). This means that the $PWD inside the
         #     container becomes a source of irreproducibility. --no-cwd disables
         #     this behaviour.
         #
         #   --share=SPEC       for containers, share writable host file system
         #                      according to SPEC
         #
-        #   --share="$PWD"=/bitcoin
+        #   --share="$PWD"=/peercoin
         #
-        #                     maps our current working directory to /bitcoin
+        #                     maps our current working directory to /peercoin
         #                     inside the isolated container, which we later cd
         #                     into.
         #
         #     While we don't want to map our current working directory to the
         #     same exact path (as this introduces irreproducibility), we do want
         #     it to be at a _fixed_ path _somewhere_ inside the isolated
-        #     container so that we have something to build. '/bitcoin' was
+        #     container so that we have something to build. '/peercoin' was
         #     chosen arbitrarily.
         #
         #   ${SOURCES_PATH:+--share="$SOURCES_PATH"}
@@ -413,7 +413,7 @@ EOF
         #
         #   --keep-failed     keep build tree of failed builds
         #
-        #     When builds of the Guix environment itself (not Bitcoin Core)
+        #     When builds of the Guix environment itself (not Peercoin)
         #     fail, it is useful for the build tree to be kept for debugging
         #     purposes.
         #
@@ -432,7 +432,7 @@ EOF
                                  --container \
                                  --pure \
                                  --no-cwd \
-                                 --share="$PWD"=/bitcoin \
+                                 --share="$PWD"=/peercoin \
                                  --share="$DISTSRC_BASE"=/distsrc-base \
                                  --share="$OUTDIR_BASE"=/outdir-base \
                                  --expose="$(git rev-parse --git-common-dir)" \
@@ -457,7 +457,7 @@ EOF
                                         DISTSRC="$(DISTSRC_BASE=/distsrc-base && distsrc_for_host "$HOST")" \
                                         OUTDIR="$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST")" \
                                         DIST_ARCHIVE_BASE=/outdir-base/dist-archive \
-                                      bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
+                                      bash -c "cd /peercoin && bash contrib/guix/libexec/build.sh"
     )
 
 done

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -199,6 +199,10 @@ make -C depends --jobs="$JOBS" HOST="$HOST" \
 # Source Tarball Building #
 ###########################
 
+if [ -z "$GITHUB_ACTIONS" ]; then
+    git config --global --add safe.directory "${PWD}"
+fi
+
 GIT_ARCHIVE="${DIST_ARCHIVE_BASE}/${DISTNAME}.tar.gz"
 
 # Create the source tarball if not already there


### PR DESCRIPTION
Caveat: I have not yet found a proper way to cache system packages from guix without exceeding the gh action cache size limit of 10GB, so builds will be slower for the time being.