### PR TITLE
make binary build cancelable and fix deprecation warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,11 +400,16 @@ jobs:
       - name: Check latest
         id: detect-publish-latest
         if: steps.detect.outputs.tag-name != 'noop' && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release-'))
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           PUBLISH=noop
           git fetch origin +refs/tags/latest:refs/tags/latest
           if ! git merge-base --is-ancestor refs/tags/latest HEAD; then
             PUBLISH=op
+            if gh release list --repo ${{ github.repository }} | grep "latest"; then
+              gh release delete latest --cleanup-tag --yes --repo ${{ github.repository }}
+            fi
           fi
           echo "publish=$PUBLISH" >> $GITHUB_OUTPUT
 
@@ -414,18 +419,19 @@ jobs:
           git fetch --depth=1 origin +${{ github.ref }}:${{ github.ref }}
           git tag -l --format='%(contents)' ${GITHUB_REF/refs\/tags\//} > ${{ github.workspace }}-CHANGELOG.txt
 
-      - uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
+      - uses: softprops/action-gh-release@v2
         if: steps.detect.outputs.tag-name != 'noop' && steps.detect-publish-latest.outputs.publish == 'op' && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release-'))
         with:
-          repo_token: ${{ github.token }}
-          automatic_release_tag: ${{ steps.detect.outputs.tag-name }}
+          tag_name: ${{ steps.detect.outputs.tag-name }}
+          token: ${{ github.token }}
           prerelease: true
-          title: "${{ steps.detect.outputs.release-title }}"
+          name: "${{ steps.detect.outputs.release-title }}"
           files: ${{ steps.detect.outputs.tag-name }}/*
 
-      - uses: softprops/action-gh-release@6034af24fba4e5a8e975aaa6056554efe4c794d0
+      - uses: softprops/action-gh-release@v2
         if: steps.detect.outputs.tag-name != 'noop' && startsWith(github.ref, 'refs/tags/v')
         with:
+          tag_name: ${{ steps.detect.outputs.tag-name }}
           body_path: ${{ github.workspace }}-CHANGELOG.txt
           token: ${{ github.token }}
           prerelease: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
   binary:
     runs-on: ubuntu-24.04
     needs: [guix-base, guix-host]
-    if: always()
+    if: ${{ !cancelled() }}
     strategy:
       matrix:
         host:


### PR DESCRIPTION
Same effect as before, but now you can actually cancel the run if needed. Otherwise it might end up running indefinitely.
Should also fix a longstanding deprecation warning on release.